### PR TITLE
feat: Update proto && Accept did core spec input [DEV-2113]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,9 @@ jobs:
       - name: Download binary artifact
         run: |
           mkdir -p ${{ env.RUNNER_BIN_DIR }}
-          wget -c https://github.com/cheqd/cheqd-node/releases/download/v1.0.4-develop.1/cheqd-noded-1.0.4-develop.1-Linux-x86_64.tar.gz
-          tar -xvf cheqd-noded-1.0.4-develop.1-Linux-x86_64.tar.gz -C ${{ env.RUNNER_BIN_DIR }}
+          CHEQD_NODE_VERSION="$(cut -c2- <<< "$(jq -r 'map(select(.prerelease)) | first | .tag_name' <<< "$(curl --silent https://api.github.com/repos/cheqd/cheqd-node/releases)")")"
+          wget -c "https://github.com/cheqd/cheqd-node/releases/download/v$CHEQD_NODE_VERSION/cheqd-noded-$CHEQD_NODE_VERSION-Linux-x86_64.tar.gz"
+          tar -xvf "cheqd-noded-$CHEQD_NODE_VERSION-Linux-x86_64.tar.gz" -C ${{ env.RUNNER_BIN_DIR }}
           sudo chmod +x ${{ env.RUNNER_BIN_DIR }}/cheqd-noded
 
       - name: Restore binary permissions
@@ -45,7 +46,10 @@ jobs:
       - name: Set up Docker localnet
         working-directory: ./docker/localnet
         run: |
-          docker compose --env-file build-latest.env up --detach --no-build
+          CHEQD_NODE_VERSION="$(cut -c2- <<< "$(jq -r 'map(select(.prerelease)) | first | .tag_name' <<< "$(curl --silent https://api.github.com/repos/cheqd/cheqd-node/releases)")")"
+          BUILD_IMAGE="ghcr.io/cheqd/cheqd-node:$CHEQD_NODE_VERSION"
+          export BUILD_IMAGE
+          docker compose up --detach
 
       - name: Import keys
         working-directory: ./docker/localnet

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@cheqd/sdk",
-  "version": "1.4.0-develop.5",
+  "version": "1.5.0-develop.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cheqd/sdk",
-      "version": "1.4.0-develop.5",
+      "version": "1.5.0-develop.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cheqd/ts-proto": "^1.0.16-develop.2",
+        "@cheqd/ts-proto": "^1.0.16-develop.3",
         "@cosmjs/amino": "^0.29.4",
         "@cosmjs/encoding": "^0.29.4",
         "@cosmjs/math": "^0.29.4",
@@ -635,9 +635,9 @@
       "dev": true
     },
     "node_modules/@cheqd/ts-proto": {
-      "version": "1.0.16-develop.2",
-      "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-1.0.16-develop.2.tgz",
-      "integrity": "sha512-bx44Fe0Q/tfrGGfkt46Lx0Pjoo9gM1mfgAB54bPt1MEqM6lsgczP+SYINEwOIW8clwd6P6Ks6SVKetU2piIAuw==",
+      "version": "1.0.16-develop.3",
+      "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-1.0.16-develop.3.tgz",
+      "integrity": "sha512-2CinyDOuCvk8/RXpQyRN8/OHYhvr7JWgJnny/CYz7EoNlxDeK8N/+Bfijncx5bQh4S+Evw9GE0i1vCcwF0wmQQ==",
       "dependencies": {
         "long": "^5.2.1",
         "protobufjs": "~7.1.1"
@@ -677,6 +677,7 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -2495,6 +2496,7 @@
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
       "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -10117,9 +10119,9 @@
       "dev": true
     },
     "@cheqd/ts-proto": {
-      "version": "1.0.16-develop.2",
-      "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-1.0.16-develop.2.tgz",
-      "integrity": "sha512-bx44Fe0Q/tfrGGfkt46Lx0Pjoo9gM1mfgAB54bPt1MEqM6lsgczP+SYINEwOIW8clwd6P6Ks6SVKetU2piIAuw==",
+      "version": "1.0.16-develop.3",
+      "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-1.0.16-develop.3.tgz",
+      "integrity": "sha512-2CinyDOuCvk8/RXpQyRN8/OHYhvr7JWgJnny/CYz7EoNlxDeK8N/+Bfijncx5bQh4S+Evw9GE0i1vCcwF0wmQQ==",
       "requires": {
         "long": "^5.2.1",
         "protobufjs": "~7.1.1"
@@ -10156,7 +10158,8 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@confio/ics23": {
       "version": "0.6.8",
@@ -11665,6 +11668,7 @@
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
       "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@colors/colors": "1.5.0",
         "string-width": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/cheqd/sdk#readme",
   "dependencies": {
-    "@cheqd/ts-proto": "^1.0.16-develop.2",
+    "@cheqd/ts-proto": "^1.0.16-develop.3",
     "@cosmjs/amino": "^0.29.4",
     "@cosmjs/encoding": "^0.29.4",
     "@cosmjs/math": "^0.29.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,5 @@ export {
 	createKeyPairHex,
 	createVerificationKeys,
 	createDidVerificationMethod,
-	createDidPayload,
-	createDidPayloadWithSignInputs,
-	createSignInputsFromKeyPair
+	createDidPayload
 } from './utils'

--- a/src/modules/did.ts
+++ b/src/modules/did.ts
@@ -2,16 +2,14 @@ import { createProtobufRpcClient, DeliverTxResponse, QueryClient } from "@cosmjs
 /* import { QueryClientImpl } from '@cheqd/ts-proto/cheqd/did/v1/query' */
 import { CheqdExtension, AbstractCheqdSDKModule, MinimalImportableCheqdSDKModule } from "./_"
 import { CheqdSigningStargateClient } from "../signer"
-import { DidStdFee, IContext, ISignInputs, MsgCreateDidPayload, MsgDeactivateDidPayload, MsgUpdateDidPayload } from "../types"
+import { DidStdFee, IContext, ISignInputs, MsgCreateDidPayload, MsgDeactivateDidPayload, MsgUpdateDidPayload, VerificationMethodPayload } from "../types"
 import { 
 	MsgCreateDidDoc, 
-	MsgCreateDidDocPayload, 
 	MsgCreateDidDocResponse, 
 	MsgDeactivateDidDoc, 
 	MsgDeactivateDidDocPayload, 
 	MsgDeactivateDidDocResponse, 
 	MsgUpdateDidDoc, 
-	MsgUpdateDidDocPayload, 
 	MsgUpdateDidDocResponse, 
 	protobufPackage 
 } from "@cheqd/ts-proto/cheqd/did/v2"
@@ -84,6 +82,8 @@ export class DIDModule extends AbstractCheqdSDKModule {
         [typeUrlMsgCreateDidDocResponse, MsgCreateDidDocResponse],
         [typeUrlMsgUpdateDidDoc, MsgUpdateDidDoc],
         [typeUrlMsgUpdateDidDocResponse, MsgUpdateDidDocResponse],
+		[typeUrlMsgDeactivateDidDoc, MsgDeactivateDidDoc],
+		[typeUrlMsgDeactivateDidDocResponse, MsgDeactivateDidDocResponse],
     ]
 
 	constructor(signer: CheqdSigningStargateClient) {
@@ -157,7 +157,7 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		}
 
 		const payload = MsgDeactivateDidDocPayload.fromPartial({id: didPayload.id, versionId: didPayload.versionId})
-		const signatures = await this._signer.signDeactivateDidTx(signInputs, payload, didPayload.verificationMethod)
+		const signatures = await this._signer.signDeactivateDidTx(signInputs, payload, didPayload.verificationMethod.map((e)=>VerificationMethodPayload.transformPayload(e)))
 
 		const value: MsgDeactivateDidDoc = {
 			payload,

--- a/src/modules/did.ts
+++ b/src/modules/did.ts
@@ -2,7 +2,7 @@ import { createProtobufRpcClient, DeliverTxResponse, QueryClient } from "@cosmjs
 /* import { QueryClientImpl } from '@cheqd/ts-proto/cheqd/did/v1/query' */
 import { CheqdExtension, AbstractCheqdSDKModule, MinimalImportableCheqdSDKModule } from "./_"
 import { CheqdSigningStargateClient } from "../signer"
-import { DidStdFee, IContext, ISignInputs, MsgDeactivateDidPayload } from "../types"
+import { DidStdFee, IContext, ISignInputs, MsgCreateDidPayload, MsgDeactivateDidPayload, MsgUpdateDidPayload } from "../types"
 import { 
 	MsgCreateDidDoc, 
 	MsgCreateDidDocPayload, 
@@ -99,12 +99,12 @@ export class DIDModule extends AbstractCheqdSDKModule {
         return DIDModule.registryTypes
     }
 
-	async createDidTx(signInputs: ISignInputs[], didPayload: Partial<MsgCreateDidDocPayload>, address: string, fee: DidStdFee | 'auto' | number, memo?: string, context?: IContext): Promise<DeliverTxResponse> {
+	async createDidTx(signInputs: ISignInputs[], didPayload: Partial<MsgCreateDidPayload>, address: string, fee: DidStdFee | 'auto' | number, memo?: string, context?: IContext): Promise<DeliverTxResponse> {
 		if (!this._signer) {
 			this._signer = context!.sdk!.signer
 		}
 
-		const payload = MsgCreateDidDocPayload.fromPartial(didPayload)
+		const payload = MsgCreateDidDocPayload.fromPartial(MsgCreateDidPayload.transformPayload(didPayload))
 		const signatures = await this._signer.signCreateDidTx(signInputs, payload)
 
 		const value: MsgCreateDidDoc = {
@@ -125,12 +125,12 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		)
 	}
 
-	async updateDidTx(signInputs: ISignInputs[], didPayload: Partial<MsgUpdateDidDocPayload>, address: string, fee: DidStdFee | 'auto' | number, memo?: string, context?: IContext): Promise<DeliverTxResponse> {
+	async updateDidTx(signInputs: ISignInputs[], didPayload: Partial<MsgUpdateDidPayload>, address: string, fee: DidStdFee | 'auto' | number, memo?: string, context?: IContext): Promise<DeliverTxResponse> {
 		if (!this._signer) {
 			this._signer = context!.sdk!.signer
 		}
 
-		const payload = MsgUpdateDidDocPayload.fromPartial(didPayload)
+		const payload = MsgUpdateDidDocPayload.fromPartial(MsgCreateDidPayload.transformPayload(didPayload))
 		const signatures = await this._signer.signUpdateDidTx(signInputs, payload)
 
 		const value: MsgUpdateDidDoc = {

--- a/src/modules/did.ts
+++ b/src/modules/did.ts
@@ -11,7 +11,8 @@ import {
 	MsgDeactivateDidDocResponse, 
 	MsgUpdateDidDoc, 
 	MsgUpdateDidDocResponse, 
-	protobufPackage 
+	protobufPackage, 
+	SignInfo
 } from "@cheqd/ts-proto/cheqd/did/v2"
 import { EncodeObject, GeneratedType } from "@cosmjs/proto-signing"
 
@@ -99,13 +100,18 @@ export class DIDModule extends AbstractCheqdSDKModule {
         return DIDModule.registryTypes
     }
 
-	async createDidTx(signInputs: ISignInputs[], didPayload: Partial<MsgCreateDidPayload>, address: string, fee: DidStdFee | 'auto' | number, memo?: string, context?: IContext): Promise<DeliverTxResponse> {
+	async createDidTx(signInputs: ISignInputs[] | SignInfo[], didPayload: Partial<MsgCreateDidPayload>, address: string, fee: DidStdFee | 'auto' | number, memo?: string, context?: IContext): Promise<DeliverTxResponse> {
 		if (!this._signer) {
 			this._signer = context!.sdk!.signer
 		}
 
 		const payload = MsgCreateDidPayload.transformPayload(didPayload)
-		const signatures = await this._signer.signCreateDidTx(signInputs, payload)
+		let signatures: SignInfo[]
+		if(ISignInputs.isSignInput(signInputs)) {
+			signatures = await this._signer.signCreateDidTx(signInputs, payload)
+		} else {
+			signatures = signInputs
+		}
 
 		const value: MsgCreateDidDoc = {
 			payload,
@@ -125,13 +131,18 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		)
 	}
 
-	async updateDidTx(signInputs: ISignInputs[], didPayload: Partial<MsgUpdateDidPayload>, address: string, fee: DidStdFee | 'auto' | number, memo?: string, context?: IContext): Promise<DeliverTxResponse> {
+	async updateDidTx(signInputs: ISignInputs[] | SignInfo[], didPayload: Partial<MsgUpdateDidPayload>, address: string, fee: DidStdFee | 'auto' | number, memo?: string, context?: IContext): Promise<DeliverTxResponse> {
 		if (!this._signer) {
 			this._signer = context!.sdk!.signer
 		}
 
 		const payload = MsgCreateDidPayload.transformPayload(didPayload)
-		const signatures = await this._signer.signUpdateDidTx(signInputs, payload)
+		let signatures: SignInfo[]
+		if(ISignInputs.isSignInput(signInputs)) {
+			signatures = await this._signer.signUpdateDidTx(signInputs, payload)
+		} else {
+			signatures = signInputs
+		}
 
 		const value: MsgUpdateDidDoc = {
 			payload,
@@ -151,13 +162,18 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		)
 	}
 
-	async deactivateDidTx(signInputs: ISignInputs[], didPayload: MsgDeactivateDidPayload, address: string, fee: DidStdFee | 'auto' | number, memo?: string, context?: IContext): Promise<DeliverTxResponse> {
+	async deactivateDidTx(signInputs: ISignInputs[] | SignInfo[], didPayload: MsgDeactivateDidPayload, address: string, fee: DidStdFee | 'auto' | number, memo?: string, context?: IContext): Promise<DeliverTxResponse> {
 		if (!this._signer) {
 			this._signer = context!.sdk!.signer
 		}
 
 		const payload = MsgDeactivateDidDocPayload.fromPartial({id: didPayload.id, versionId: didPayload.versionId})
-		const signatures = await this._signer.signDeactivateDidTx(signInputs, payload, didPayload.verificationMethod.map((e)=>VerificationMethodPayload.transformPayload(e)))
+		let signatures: SignInfo[]
+		if(ISignInputs.isSignInput(signInputs)) {
+			signatures = await this._signer.signDeactivateDidTx(signInputs, payload, didPayload.verificationMethod.map((e)=>VerificationMethodPayload.transformPayload(e)))
+		} else {
+			signatures = signInputs
+		}
 
 		const value: MsgDeactivateDidDoc = {
 			payload,

--- a/src/modules/did.ts
+++ b/src/modules/did.ts
@@ -104,7 +104,7 @@ export class DIDModule extends AbstractCheqdSDKModule {
 			this._signer = context!.sdk!.signer
 		}
 
-		const payload = MsgCreateDidDocPayload.fromPartial(MsgCreateDidPayload.transformPayload(didPayload))
+		const payload = MsgCreateDidPayload.transformPayload(didPayload)
 		const signatures = await this._signer.signCreateDidTx(signInputs, payload)
 
 		const value: MsgCreateDidDoc = {
@@ -130,7 +130,7 @@ export class DIDModule extends AbstractCheqdSDKModule {
 			this._signer = context!.sdk!.signer
 		}
 
-		const payload = MsgUpdateDidDocPayload.fromPartial(MsgCreateDidPayload.transformPayload(didPayload))
+		const payload = MsgCreateDidPayload.transformPayload(didPayload)
 		const signatures = await this._signer.signUpdateDidTx(signInputs, payload)
 
 		const value: MsgUpdateDidDoc = {

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -4,7 +4,7 @@ import { DeliverTxResponse, GasPrice, HttpEndpoint, QueryClient, SigningStargate
 import { Tendermint34Client } from "@cosmjs/tendermint-rpc"
 import { createDefaultCheqdRegistry } from "./registry"
 import { MsgCreateDidDocPayload, SignInfo, MsgUpdateDidDocPayload, MsgDeactivateDidDocPayload, VerificationMethod } from '@cheqd/ts-proto/cheqd/did/v2';
-import { DidStdFee, ISignInputs, TSignerAlgo, VerificationMethods } from './types';
+import { DidStdFee, ISignInputs, TSignerAlgo, VerificationMethodPayload, VerificationMethods } from './types';
 import { base64ToBytes, EdDSASigner, hexToBytes, Signer, ES256Signer, ES256KSigner } from 'did-jwt';
 import { assert, assertDefined } from '@cosmjs/utils'
 import { encodeSecp256k1Pubkey } from '@cosmjs/amino'

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -176,11 +176,11 @@ export class CheqdSigningStargateClient extends SigningStargateClient {
 		}
 
 		verificationMethods.forEach((verificationMethod) => {
-			if (!(Object.values(VerificationMethods) as string[]).includes(verificationMethod.type ?? '')) {
-				throw new Error(`Unsupported verification method type: ${verificationMethod.type}`)
+			if (!(Object.values(VerificationMethods) as string[]).includes(verificationMethod.verificationMethodType ?? '')) {
+				throw new Error(`Unsupported verification method type: ${verificationMethod.verificationMethodType}`)
 			}
-			if (!this.didSigners[verificationMethod.type ?? '']) {
-				this.didSigners[verificationMethod.type ?? ''] = EdDSASigner
+			if (!this.didSigners[verificationMethod.verificationMethodType ?? '']) {
+				this.didSigners[verificationMethod.verificationMethodType ?? ''] = EdDSASigner
 			}
 		})
 
@@ -189,7 +189,7 @@ export class CheqdSigningStargateClient extends SigningStargateClient {
 
 	async getDidSigner(verificationMethodId: string, verificationMethods: Partial<VerificationMethod>[]): Promise<(secretKey: Uint8Array) => Signer> {
 		await this.checkDidSigners(verificationMethods)
-		const verificationMethod = verificationMethods.find(method => method.id === verificationMethodId)?.type
+		const verificationMethod = verificationMethods.find(method => method.id === verificationMethodId)?.verificationMethodType
 		if (!verificationMethod) {
 			throw new Error(`Verification method for ${verificationMethodId} not found`)
 		}

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,12 @@ export interface ISignInputs {
     privateKeyHex: string
 }
 
+export const ISignInputs = {
+  isSignInput(object: Object[]): object is ISignInputs[] {
+		return object.some((x)=> 'privateKeyHex' in x)
+	}
+}
+
 export interface IKeyPair {
     publicKey: string
     privateKey: string
@@ -171,9 +177,13 @@ export const VerificationMethodPayload = {
         message.id = object.id ?? "";
         message.type = object.type ?? "";
         message.controller = object.controller ?? "";
-        message.publicKeyMultibase = object.publicKeyMultibase ?? "";
-        message.publicKeyBase58 = object.publicKeyBase58 ?? "";
-        message.publicKeyJWK = object.publicKeyJWK ?? {};
+        if(object.publicKeyMultibase) {
+          message.publicKeyMultibase = object.publicKeyMultibase;
+        } else if (object.publicKeyBase58) {
+          message.publicKeyBase58 = object.publicKeyBase58;
+        } else if (object.publicKeyJWK) {
+          message.publicKeyJWK = object.publicKeyJWK;
+        }
         return message;
       },
     

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,7 +81,7 @@ export interface MsgCreateDidPayload extends Omit<MsgCreateDidDocPayload, 'verif
 }
 
 export const MsgCreateDidPayload = {
-    transformPayload<I extends Exact<DeepPartial<MsgCreateDidPayload>, I>>(message: I): Partial<MsgCreateDidDocPayload> {
+    transformPayload<I extends Exact<DeepPartial<MsgCreateDidPayload>, I>>(message: I): MsgCreateDidDocPayload {
         const obj: any = {};
         if (message.context) {
           obj.context = message.context
@@ -117,7 +117,7 @@ export const MsgCreateDidPayload = {
           obj.service = message.service.map((e) => e ? {id: e.id, serviceEndpoint: e.serviceEndpoint, serviceType: e.type} as Service : undefined);
         }
         message.versionId !== undefined && (obj.versionId = message.versionId);
-        return obj;
+        return MsgCreateDidDocPayload.fromPartial(obj);
       },
 
     fromPartial<I extends Exact<DeepPartial<MsgCreateDidPayload>, I>>(object: I): MsgCreateDidPayload {

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,7 +72,7 @@ export interface DidStdFee {
 }
 
 export interface MsgDeactivateDidPayload extends MsgDeactivateDidDocPayload {
-    verificationMethod: VerificationMethod[]
+    verificationMethod: VerificationMethodPayload[]
 }
 
 export interface MsgCreateDidPayload extends Omit<MsgCreateDidDocPayload, 'verificationMethod' | 'service'> {
@@ -93,7 +93,7 @@ export const MsgCreateDidPayload = {
           obj.controller = message.controller
         }
         if (message.verificationMethod) {
-          obj.verificationMethod = message.verificationMethod.map((e) => e ? {id: e.id, controller: e.controller, verificationMethodType: e.type, verificationMaterial: e.publicKeyBase58 || e.publicKeyMultibase || JSON.stringify(e.publicKeyJWK) } as VerificationMethod : undefined);
+          obj.verificationMethod = message.verificationMethod.map((e) => e ? VerificationMethodPayload.transformPayload(e) : undefined);
         }
         if (message.authentication) {
           obj.authentication = message.authentication
@@ -176,6 +176,15 @@ export const VerificationMethodPayload = {
         message.publicKeyJWK = object.publicKeyJWK ?? {};
         return message;
       },
+    
+    transformPayload<I extends Exact<DeepPartial<VerificationMethodPayload>, I>>(payload: I): VerificationMethod {
+      return {
+        id: payload.id ?? "", 
+        controller: payload.controller ?? "", 
+        verificationMethodType: payload.type ?? "", 
+        verificationMaterial: payload.publicKeyBase58 || payload.publicKeyMultibase || JSON.stringify(payload.publicKeyJWK) || ""
+      } as VerificationMethod
+    }
 }
 
 function createBaseVerificationMethod(): VerificationMethodPayload {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
 import { CheqdSDK } from "."
 import { Coin } from "@cosmjs/proto-signing"
 import { Signer } from "did-jwt"
-import { MsgDeactivateDidDocPayload, VerificationMethod } from "@cheqd/ts-proto/cheqd/did/v2"
+import { MsgCreateDidDocPayload, MsgDeactivateDidDocPayload, MsgUpdateDidDocPayload, VerificationMethod, Service } from "@cheqd/ts-proto/cheqd/did/v2"
+import { DeepPartial, Exact } from "cosmjs-types/confio/proofs"
 
 export enum CheqdNetwork {
     Mainnet = 'mainnet',
@@ -19,7 +20,8 @@ export interface IContext {
 }
 
 export enum VerificationMethods {
-    Base58 = 'Ed25519VerificationKey2020',
+    Ed255192020 = 'Ed25519VerificationKey2020',
+    Ed255192018 = 'Ed25519VerificationKey2018',
     JWK = 'JsonWebKey2020',
 }
 
@@ -71,4 +73,136 @@ export interface DidStdFee {
 
 export interface MsgDeactivateDidPayload extends MsgDeactivateDidDocPayload {
     verificationMethod: VerificationMethod[]
+}
+
+export interface MsgCreateDidPayload extends Omit<MsgCreateDidDocPayload, 'verificationMethod' | 'service'> {
+    verificationMethod: VerificationMethodPayload[]
+    service: ServicePayload[]
+}
+
+export const MsgCreateDidPayload = {
+    transformPayload<I extends Exact<DeepPartial<MsgCreateDidPayload>, I>>(message: I): Partial<MsgCreateDidDocPayload> {
+        const obj: any = {};
+        if (message.context) {
+          obj.context = message.context
+        } else {
+          obj.context = [];
+        }
+        message.id !== undefined && (obj.id = message.id);
+        if (message.controller) {
+          obj.controller = message.controller
+        }
+        if (message.verificationMethod) {
+          obj.verificationMethod = message.verificationMethod.map((e) => e ? {id: e.id, controller: e.controller, verificationMethodType: e.type, verificationMaterial: e.publicKeyBase58 || e.publicKeyMultibase || JSON.stringify(e.publicKeyJWK) } as VerificationMethod : undefined);
+        }
+        if (message.authentication) {
+          obj.authentication = message.authentication
+        }
+        if (message.assertionMethod) {
+          obj.assertionMethod = message.assertionMethod
+        }
+        if (message.capabilityInvocation) {
+          obj.capabilityInvocation = message.capabilityInvocation
+        }
+        if (message.capabilityDelegation) {
+          obj.capabilityDelegation = message.capabilityDelegation
+        }
+        if (message.keyAgreement) {
+          obj.keyAgreement = message.keyAgreement
+        }
+        if (message.alsoKnownAs) {
+          obj.alsoKnownAs = message.alsoKnownAs
+        }
+        if (message.service) {
+          obj.service = message.service.map((e) => e ? {id: e.id, serviceEndpoint: e.serviceEndpoint, serviceType: e.type} as Service : undefined);
+        }
+        message.versionId !== undefined && (obj.versionId = message.versionId);
+        return obj;
+      },
+
+    fromPartial<I extends Exact<DeepPartial<MsgCreateDidPayload>, I>>(object: I): MsgCreateDidPayload {
+        const message = createBaseMsgCreateDidPayload();
+        message.context = object.context?.map((e) => e) || [];
+        message.id = object.id ?? "";
+        message.controller = object.controller?.map((e) => e) || [];
+        message.verificationMethod = object.verificationMethod?.map((e) => VerificationMethodPayload.fromPartial(e)) || [];
+        message.authentication = object.authentication?.map((e) => e) || [];
+        message.assertionMethod = object.assertionMethod?.map((e) => e) || [];
+        message.capabilityInvocation = object.capabilityInvocation?.map((e) => e) || [];
+        message.capabilityDelegation = object.capabilityDelegation?.map((e) => e) || [];
+        message.keyAgreement = object.keyAgreement?.map((e) => e) || [];
+        message.alsoKnownAs = object.alsoKnownAs?.map((e) => e) || [];
+        message.service = object.service?.map((e) => ServicePayload.fromPartial(e)) || [];
+        message.versionId = object.versionId ?? "";
+        return message;
+    },
+    
+}
+
+function createBaseMsgCreateDidPayload(): MsgCreateDidPayload {
+    return {
+      context: [],
+      id: "",
+      controller: [],
+      verificationMethod: [],
+      authentication: [],
+      assertionMethod: [],
+      capabilityInvocation: [],
+      capabilityDelegation: [],
+      keyAgreement: [],
+      alsoKnownAs: [],
+      service: [],
+      versionId: "",
+    };
+  }
+
+export interface VerificationMethodPayload {
+    id: string;
+    type: string;
+    controller: string;
+    publicKeyBase58?: string;
+    publicKeyMultibase?: string;
+    publicKeyJWK?: any;
+}
+
+export const VerificationMethodPayload = {
+    fromPartial<I extends Exact<DeepPartial<VerificationMethodPayload>, I>>(object: I): VerificationMethodPayload {
+        const message = createBaseVerificationMethod();
+        message.id = object.id ?? "";
+        message.type = object.type ?? "";
+        message.controller = object.controller ?? "";
+        message.publicKeyMultibase = object.publicKeyMultibase ?? "";
+        message.publicKeyBase58 = object.publicKeyBase58 ?? "";
+        message.publicKeyJWK = object.publicKeyJWK ?? {};
+        return message;
+      },
+}
+
+function createBaseVerificationMethod(): VerificationMethodPayload {
+    return { id: "", type: "", controller: ""  };
+}
+
+export interface ServicePayload {
+    id: string;
+    type: string;
+    serviceEndpoint: string[];
+}
+
+export const ServicePayload = {
+    fromPartial<I extends Exact<DeepPartial<ServicePayload>, I>>(object: I): ServicePayload {
+        const message = createBaseService();
+        message.id = object.id ?? "";
+        message.type = object.type ?? "";
+        message.serviceEndpoint = object.serviceEndpoint?.map((e) => e) || [];
+        return message;
+      },
+}
+
+function createBaseService(): ServicePayload {
+    return { id: "", type: "", serviceEndpoint: [] };
+}
+
+export interface MsgUpdateDidPayload extends Omit<MsgUpdateDidDocPayload, 'verificationMethod' | 'service'> {
+    verificationMethod: VerificationMethodPayload[]
+    service: ServicePayload[]
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -204,7 +204,7 @@ export function createDidPayloadWithSignInputs(seed?: string, keys?: IKeyPair[])
     const keyHexs = keys.map((key)=>convertKeyPairtoTImportableEd25519Key(key))
     const signInputs = keyHexs.map((key)=>createSignInputsFromImportableEd25519Key(key, verificationMethod))
 
-    return { didPayload: MsgCreateDidDocPayload.fromPartial(payload), keys, signInputs }
+    return { didPayload: MsgCreateDidPayload.fromPartial(payload), keys, signInputs }
 }
 
 export function convertKeyPairtoTImportableEd25519Key(keyPair: IKeyPair) : TImportableEd25519Key {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,10 @@ import {
     TVerificationKey, 
     TVerificationKeyPrefix, 
     CheqdNetwork, 
-    IVerificationKeys 
+    IVerificationKeys, 
+    MsgCreateDidPayload,
+    VerificationMethodPayload,
+    MsgUpdateDidPayload
 } from "./types"
 import { fromString, toString } from 'uint8arrays'
 import { bases } from "multiformats/basics"
@@ -32,22 +35,31 @@ export type TImportableEd25519Key = {
 // multicodec ed25519-pub header as varint
 const MULTICODEC_ED25519_PUB_HEADER = new Uint8Array([0xed, 0x01]);
 
-export type IdentifierPayload = Partial<MsgCreateDidDocPayload> | Partial<MsgUpdateDidDocPayload>
+export type IdentifierPayload = Partial<MsgCreateDidPayload> | Partial<MsgUpdateDidPayload>
 
 export function isEqualKeyValuePair(kv1: IKeyValuePair[], kv2: IKeyValuePair[]): boolean {
     return kv1.every((item, index) => item.key === kv2[index].key && item.value === kv2[index].value)
 }
 
-export function createSignInputsFromImportableEd25519Key(key: TImportableEd25519Key, verificationMethod: VerificationMethod[]): ISignInputs {
+export function createSignInputsFromImportableEd25519Key(key: TImportableEd25519Key, verificationMethod: VerificationMethodPayload[]): ISignInputs {
     if (verificationMethod?.length === 0) throw new Error('No verification methods provided')
 
     const publicKey = fromString(key.publicKeyHex, 'hex')
 
     for(const method of verificationMethod) {
         switch (method?.type) {
-            case VerificationMethods.Base58:
-                const publicKeyMultibase = bases['base58btc'].encode(publicKey)
-                if ((JSON.parse(method.verificationMaterial)).publicKeyMultibase === publicKeyMultibase) {
+            case VerificationMethods.Ed255192020:
+                const publicKeyMultibase = _encodeMbKey(MULTICODEC_ED25519_PUB_HEADER, publicKey)
+                if (method.publicKeyMultibase === publicKeyMultibase) {
+                    return {
+                        verificationMethodId: method.id,
+                        privateKeyHex: key.privateKeyHex
+                    }
+                }
+            
+            case VerificationMethods.Ed255192018:
+                const publicKeyBase58 = bases['base58btc'].encode(publicKey).slice(1)
+                if (method.publicKeyBase58 === publicKeyBase58) {
                     return {
                         verificationMethodId: method.id,
                         privateKeyHex: key.privateKeyHex
@@ -55,12 +67,12 @@ export function createSignInputsFromImportableEd25519Key(key: TImportableEd25519
                 }
 
             case VerificationMethods.JWK:
-                const publicKeyJWK = {
+                const publicKeyJWK: any = {
                     crv: 'Ed25519',
                     kty: 'OKP',
                     x: toString( publicKey, 'base64url' )
                 }
-                if ((JSON.parse(method.verificationMaterial)).publicKeyJwk, publicKeyJWK) {
+                if (method.publicKeyJWK! === publicKeyJWK) {
                     return {
                         verificationMethodId: method.id,
                         privateKeyHex: key.privateKeyHex
@@ -117,46 +129,49 @@ export function createVerificationKeys(keyPair: IKeyPair, algo: MethodSpecificId
     }
 }
 
-export function createDidVerificationMethod(verificationMethodTypes: VerificationMethods[], verificationKeys: IVerificationKeys[]): VerificationMethod[] {
+export function createDidVerificationMethod(verificationMethodTypes: VerificationMethods[], verificationKeys: IVerificationKeys[]): VerificationMethodPayload[] {
     return verificationMethodTypes.map((type, _) => {
         switch (type) {
-            case VerificationMethods.Base58:
+            case VerificationMethods.Ed255192020:
                 return {
                     id: verificationKeys[_].keyId,
-                    type: type,
+                    type,
                     controller: verificationKeys[_].didUrl,
-                    verificationMaterial: JSON.stringify({
-                        publicKeyMultibase: verificationKeys[_].methodSpecificId,
-                        publicKeyJwk: []
-                    })
+                    publicKeyMultibase: _encodeMbKey(MULTICODEC_ED25519_PUB_HEADER, base64ToBytes(verificationKeys[_].publicKey))
+                }
+            
+            case VerificationMethods.Ed255192018:
+                return {
+                    id: verificationKeys[_].keyId,
+                    type,
+                    controller: verificationKeys[_].didUrl,
+                    publicKeyBase58: verificationKeys[_].methodSpecificId.slice(1)
                 }
 
             case VerificationMethods.JWK:
                 return {
                     id: verificationKeys[_].keyId,
-                    type: type,
+                    type,
                     controller: verificationKeys[_].didUrl,
-                    verificationMaterial: JSON.stringify({
-                        publicKeyJwk: {
+                    publicKeyJWK: JSON.stringify({
                             crv: 'Ed25519',
                             kty: 'OKP',
                             x: toString( fromString( verificationKeys[_].publicKey, 'base64pad' ), 'base64url' )
-                        },
-                        publicKeyMultibase: ''
-                    })
+                        }
+                    )
                 }
         }
     }) ?? []
 }
 
-export function createDidPayload(verificationMethods: VerificationMethod[], verificationKeys: IVerificationKeys[]): MsgCreateDidDocPayload {
+export function createDidPayload(verificationMethods: VerificationMethodPayload[], verificationKeys: IVerificationKeys[]): MsgCreateDidPayload {
     if (!verificationMethods || verificationMethods.length === 0)
         throw new Error('No verification methods provided')
     if (!verificationKeys || verificationKeys.length === 0)
         throw new Error('No verification keys provided')
 
     const did = verificationKeys[0].didUrl
-    return MsgCreateDidDocPayload.fromPartial(
+    return MsgCreateDidPayload.fromPartial(
         {
             id: did,
             controller: verificationKeys.map(key => key.didUrl),
@@ -174,11 +189,11 @@ export function createDidPayloadWithSignInputs(seed?: string, keys?: IKeyPair[])
         keys = [seed ? createKeyPairBase64(seed) : createKeyPairBase64()]
     }
 
-    const verificationMethodTypes = keys.map((key) => !key.algo || key.algo == MethodSpecificIdAlgo.Base58 ? VerificationMethods.Base58 : VerificationMethods.JWK)
+    const verificationMethodTypes = keys.map((key) => !key.algo || key.algo == MethodSpecificIdAlgo.Base58 ? VerificationMethods.Ed255192020 : VerificationMethods.JWK)
     const verificationKeys = keys.map((key, i) => createVerificationKeys(key, key.algo || MethodSpecificIdAlgo.Base58, `key-${i}`))
     const verificationMethod = createDidVerificationMethod(verificationMethodTypes, verificationKeys)
     
-    let payload : Partial<MsgCreateDidDocPayload> = {
+    let payload : Partial<MsgCreateDidPayload> = {
         id: verificationKeys[0].didUrl,
         controller: verificationKeys.map(key => key.didUrl),
         verificationMethod: verificationMethod,
@@ -202,7 +217,7 @@ export function convertKeyPairtoTImportableEd25519Key(keyPair: IKeyPair) : TImpo
 
 export function createSignInputsFromKeyPair(didDocument: IdentifierPayload, keys: IKeyPair[]) {
     const keyHexs = keys.map((key)=>convertKeyPairtoTImportableEd25519Key(key))
-    const signInputs = keyHexs.map((key)=>createSignInputsFromImportableEd25519Key(key, didDocument.verificationMethod!))
+    const signInputs = keyHexs.map((key)=>createSignInputsFromImportableEd25519Key(key, didDocument.verificationMethod || []))
     return signInputs
 }
 
@@ -211,12 +226,12 @@ function sha256(message: string) {
 }
 
 // encode a multibase base58-btc multicodec key
-// function _encodeMbKey(header: any, key: any) {
-//     const mbKey = new Uint8Array(header.length + key.length);
+function _encodeMbKey(header: any, key: Uint8Array) {
+    const mbKey = new Uint8Array(header.length + key.length);
   
-//     mbKey.set(header);
-//     mbKey.set(key, header.length);
+    mbKey.set(header);
+    mbKey.set(key, header.length);
   
-//     return bases['base58btc'].encode(mbKey);
-//   }
+    return bases['base58btc'].encode(mbKey);
+  }
   

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,11 +72,13 @@ export function createSignInputsFromImportableEd25519Key(key: TImportableEd25519
                     kty: 'OKP',
                     x: toString( publicKey, 'base64url' )
                 }
-                if (method.publicKeyJWK! === publicKeyJWK) {
+                if (JSON.stringify(method.publicKeyJWK) === JSON.stringify(publicKeyJWK)) {
                     return {
                         verificationMethodId: method.id,
                         privateKeyHex: key.privateKeyHex
                     }
+                } else {
+                    throw new Error(`JWK not matching ${method.publicKeyJWK}, ${publicKeyJWK}`)
                 }
         }
     }
@@ -153,12 +155,11 @@ export function createDidVerificationMethod(verificationMethodTypes: Verificatio
                     id: verificationKeys[_].keyId,
                     type,
                     controller: verificationKeys[_].didUrl,
-                    publicKeyJWK: JSON.stringify({
-                            crv: 'Ed25519',
-                            kty: 'OKP',
-                            x: toString( fromString( verificationKeys[_].publicKey, 'base64pad' ), 'base64url' )
-                        }
-                    )
+                    publicKeyJWK: {
+                        crv: 'Ed25519',
+                        kty: 'OKP',
+                        x: toString( fromString( verificationKeys[_].publicKey, 'base64pad' ), 'base64url' )
+                    }
                 }
         }
     }) ?? []

--- a/tests/modules/did.test.ts
+++ b/tests/modules/did.test.ts
@@ -6,7 +6,7 @@ import { v4 } from "uuid"
 import { DIDModule } from "../../src"
 import { createDefaultCheqdRegistry } from "../../src/registry"
 import { CheqdSigningStargateClient } from "../../src/signer"
-import { DidStdFee, ISignInputs, MethodSpecificIdAlgo, MsgCreateDidPayload, VerificationMethods } from "../../src/types"
+import { DidStdFee, ISignInputs, MethodSpecificIdAlgo, MsgCreateDidPayload, MsgDeactivateDidPayload, VerificationMethods } from "../../src/types"
 import { createDidPayload, createDidVerificationMethod, createKeyPairBase64, createVerificationKeys, exampleCheqdNetwork, faucet } from "../testutils.test"
 
 const defaultAsyncTxTimeout = 30000
@@ -42,7 +42,7 @@ describe('DIDModule', () => {
                 amount: [
                     {
                         denom: 'ncheq',
-                        amount: '5000000000'
+                        amount: '5000000'
                     }
                 ],
                 gas: '200000',
@@ -81,7 +81,7 @@ describe('DIDModule', () => {
                 amount: [
                     {
                         denom: 'ncheq',
-                        amount: '5000000000'
+                        amount: '5000000'
                     }
                 ],
                 gas: '200000',
@@ -122,7 +122,7 @@ describe('DIDModule', () => {
                 amount: [
                     {
                         denom: 'ncheq',
-                        amount: '5000000000'
+                        amount: '5000000'
                     }
                 ],
                 gas: '200000',
@@ -160,6 +160,64 @@ describe('DIDModule', () => {
 
             console.warn(updateDidTx)
             expect(updateDidTx.code).toBe(0)
+        }, defaultAsyncTxTimeout)
+    })
+
+    describe('deactivateDidTx', () => {
+        it('should deactivate a DID', async () => {
+            const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
+            const registry = createDefaultCheqdRegistry(DIDModule.registryTypes)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet, { registry })
+            const didModule = new DIDModule(signer)
+            
+            const keyPair = createKeyPairBase64()
+            const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
+            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+            const signInputs: ISignInputs[] = [
+                {
+                    verificationMethodId: didPayload.verificationMethod[0].id,
+                    privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
+                }
+            ]
+            const fee: DidStdFee = {
+                amount: [
+                    {
+                        denom: 'ncheq',
+                        amount: '5000000'
+                    }
+                ],
+                gas: '200000',
+                payer: (await wallet.getAccounts())[0].address
+            } 
+            const didTx: DeliverTxResponse = await didModule.createDidTx(
+                signInputs,
+                didPayload,
+                (await wallet.getAccounts())[0].address,
+                fee
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(didPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(didTx)}`)
+
+            expect(didTx.code).toBe(0)
+
+            // Update the DID
+            const deactivateDidPayload: MsgDeactivateDidPayload = {
+                id: didPayload.id,
+                verificationMethod: didPayload.verificationMethod,
+                versionId: v4()
+            }
+
+            const deactivateDidTx: DeliverTxResponse = await didModule.deactivateDidTx(
+                signInputs,
+                deactivateDidPayload,
+                (await wallet.getAccounts())[0].address,
+                fee
+            )
+
+            console.warn(deactivateDidTx)
+            expect(deactivateDidTx.code).toBe(0)
         }, defaultAsyncTxTimeout)
     })
 })

--- a/tests/modules/did.test.ts
+++ b/tests/modules/did.test.ts
@@ -6,7 +6,7 @@ import { v4 } from "uuid"
 import { DIDModule } from "../../src"
 import { createDefaultCheqdRegistry } from "../../src/registry"
 import { CheqdSigningStargateClient } from "../../src/signer"
-import { DidStdFee, ISignInputs, MethodSpecificIdAlgo, VerificationMethods } from "../../src/types"
+import { DidStdFee, ISignInputs, MethodSpecificIdAlgo, MsgCreateDidPayload, VerificationMethods } from "../../src/types"
 import { createDidPayload, createDidVerificationMethod, createKeyPairBase64, createVerificationKeys, exampleCheqdNetwork, faucet } from "../testutils.test"
 
 const defaultAsyncTxTimeout = 30000
@@ -29,7 +29,7 @@ describe('DIDModule', () => {
             const didModule = new DIDModule(signer)
             const keyPair = createKeyPairBase64()
             const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
-            const verificationMethods = createDidVerificationMethod([VerificationMethods.Base58], [verificationKeys])
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys])
 
             const signInputs: ISignInputs[] = [
@@ -68,7 +68,7 @@ describe('DIDModule', () => {
             const didModule = new DIDModule(signer)
             const keyPair = createKeyPairBase64()
             const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Uuid, 'key-1', 16)
-            const verificationMethods = createDidVerificationMethod([VerificationMethods.Base58], [verificationKeys])
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys])
             didPayload.versionId = v4()
             const signInputs: ISignInputs[] = [
@@ -110,7 +110,7 @@ describe('DIDModule', () => {
             
             const keyPair = createKeyPairBase64()
             const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
-            const verificationMethods = createDidVerificationMethod([VerificationMethods.Base58], [verificationKeys])
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys])
             const signInputs: ISignInputs[] = [
                 {
@@ -141,7 +141,7 @@ describe('DIDModule', () => {
             expect(didTx.code).toBe(0)
 
             // Update the DID
-            const updateDidPayload = MsgUpdateDidDocPayload.fromPartial({
+            const updateDidPayload = MsgCreateDidPayload.fromPartial({
                 context: didPayload.context,
                 id: didPayload.id,
                 controller: didPayload.controller,

--- a/tests/modules/did.test.ts
+++ b/tests/modules/did.test.ts
@@ -29,7 +29,7 @@ describe('DIDModule', () => {
             const didModule = new DIDModule(signer)
             const keyPair = createKeyPairBase64()
             const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
-            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.JWK], [verificationKeys])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys])
 
             const signInputs: ISignInputs[] = [

--- a/tests/modules/resource.test.ts
+++ b/tests/modules/resource.test.ts
@@ -34,7 +34,7 @@ describe('ResourceModule', () => {
 
             const keyPair = createKeyPairBase64()
             const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
-            const verificationMethods = createDidVerificationMethod([VerificationMethods.Base58], [verificationKeys])
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys])
 
             const signInputs: ISignInputs[] = [

--- a/tests/signer.test.ts
+++ b/tests/signer.test.ts
@@ -97,15 +97,18 @@ describe('CheqdSigningStargateClient', () => {
             const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
             const keyPair1 = createKeyPairBase64()
             const keyPair2 = createKeyPairBase64()
+            const keyPair3 = createKeyPairBase64()
             const verificationKeys1 = createVerificationKeys(keyPair1, MethodSpecificIdAlgo.Base58, 'key-1', 16)
             const verificationKeys2 = createVerificationKeys(keyPair2, MethodSpecificIdAlgo.Base58, 'key-2', 16)
-            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020, VerificationMethods.JWK], [verificationKeys1, verificationKeys2])
-            const didPayload = MsgCreateDidPayload.transformPayload(createDidPayload(verificationMethods, [verificationKeys1, verificationKeys2]))
+            const verificationKeys3 = createVerificationKeys(keyPair3, MethodSpecificIdAlgo.Base58, 'key-3', 16)
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020, VerificationMethods.JWK, VerificationMethods.Ed255192018], [verificationKeys1, verificationKeys2, verificationKeys3])
+            const didPayload = MsgCreateDidPayload.transformPayload(createDidPayload(verificationMethods, [verificationKeys1, verificationKeys2, verificationKeys3]))
 
             const didSigners = await signer.checkDidSigners(didPayload.verificationMethod)
 
             expect(didSigners[VerificationMethods.Ed255192020]).toBe(EdDSASigner)
             expect(didSigners[VerificationMethods.JWK]).toBe(EdDSASigner)
+            expect(didSigners[VerificationMethods.Ed255192018]).toBe(EdDSASigner)
         })
 
         it('should throw for non-supported verification method', async () => {

--- a/tests/signer.test.ts
+++ b/tests/signer.test.ts
@@ -54,7 +54,7 @@ describe('CheqdSigningStargateClient', () => {
             const keyPair = createKeyPairBase64()
             const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
             const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
-            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+            const didPayload = MsgCreateDidPayload.transformPayload(createDidPayload(verificationMethods, [verificationKeys]))
             const didSigner = await signer.getDidSigner(didPayload.verificationMethod[0].id, didPayload.verificationMethod)
 
             expect(didSigner).toBe(EdDSASigner)
@@ -85,7 +85,7 @@ describe('CheqdSigningStargateClient', () => {
             const keyPair = createKeyPairBase64()
             const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
             const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
-            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+            const didPayload = MsgCreateDidPayload.transformPayload(createDidPayload(verificationMethods, [verificationKeys]))
 
             const didSigners = await signer.checkDidSigners(didPayload.verificationMethod)
 
@@ -100,7 +100,7 @@ describe('CheqdSigningStargateClient', () => {
             const verificationKeys1 = createVerificationKeys(keyPair1, MethodSpecificIdAlgo.Base58, 'key-1', 16)
             const verificationKeys2 = createVerificationKeys(keyPair2, MethodSpecificIdAlgo.Base58, 'key-2', 16)
             const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020, VerificationMethods.JWK], [verificationKeys1, verificationKeys2])
-            const didPayload = createDidPayload(verificationMethods, [verificationKeys1, verificationKeys2])
+            const didPayload = MsgCreateDidPayload.transformPayload(createDidPayload(verificationMethods, [verificationKeys1, verificationKeys2]))
 
             const didSigners = await signer.checkDidSigners(didPayload.verificationMethod)
 

--- a/tests/signer.test.ts
+++ b/tests/signer.test.ts
@@ -3,7 +3,7 @@ import { DirectSecp256k1HdWallet, Registry } from "@cosmjs/proto-signing"
 import { EdDSASigner } from "did-jwt"
 import { typeUrlMsgCreateDidDoc } from '../src/modules/did'
 import { CheqdSigningStargateClient } from "../src/signer"
-import { ISignInputs, MethodSpecificIdAlgo, VerificationMethods } from "../src/types"
+import { ISignInputs, MethodSpecificIdAlgo, MsgCreateDidPayload, VerificationMethods } from "../src/types"
 import { fromString, toString } from 'uint8arrays'
 import { createDidPayload, createDidVerificationMethod, createKeyPairBase64, createVerificationKeys, exampleCheqdNetwork, faucet } from "./testutils.test"
 import { verify } from "@stablelib/ed25519"
@@ -53,7 +53,7 @@ describe('CheqdSigningStargateClient', () => {
             const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
             const keyPair = createKeyPairBase64()
             const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
-            const verificationMethods = createDidVerificationMethod([VerificationMethods.Base58], [verificationKeys])
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys])
             const didSigner = await signer.getDidSigner(didPayload.verificationMethod[0].id, didPayload.verificationMethod)
 
@@ -72,7 +72,7 @@ describe('CheqdSigningStargateClient', () => {
             const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
             const keyPair = createKeyPairBase64()
             const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
-            const verificationMethods = createDidVerificationMethod([VerificationMethods.Base58], [verificationKeys])
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys])
             await expect(signer.getDidSigner(nonExistingKeyId, didPayload.verificationMethod)).rejects.toThrow()
         })
@@ -84,12 +84,12 @@ describe('CheqdSigningStargateClient', () => {
             const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
             const keyPair = createKeyPairBase64()
             const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
-            const verificationMethods = createDidVerificationMethod([VerificationMethods.Base58], [verificationKeys])
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys])
 
             const didSigners = await signer.checkDidSigners(didPayload.verificationMethod)
 
-            expect(didSigners[VerificationMethods.Base58]).toBe(EdDSASigner)
+            expect(didSigners[VerificationMethods.Ed255192020]).toBe(EdDSASigner)
         })
 
         it('should instantiate multiple signers for a did with multiple verification methods', async () => {
@@ -99,12 +99,12 @@ describe('CheqdSigningStargateClient', () => {
             const keyPair2 = createKeyPairBase64()
             const verificationKeys1 = createVerificationKeys(keyPair1, MethodSpecificIdAlgo.Base58, 'key-1', 16)
             const verificationKeys2 = createVerificationKeys(keyPair2, MethodSpecificIdAlgo.Base58, 'key-2', 16)
-            const verificationMethods = createDidVerificationMethod([VerificationMethods.Base58, VerificationMethods.JWK], [verificationKeys1, verificationKeys2])
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020, VerificationMethods.JWK], [verificationKeys1, verificationKeys2])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys1, verificationKeys2])
 
             const didSigners = await signer.checkDidSigners(didPayload.verificationMethod)
 
-            expect(didSigners[VerificationMethods.Base58]).toBe(EdDSASigner)
+            expect(didSigners[VerificationMethods.Ed255192020]).toBe(EdDSASigner)
             expect(didSigners[VerificationMethods.JWK]).toBe(EdDSASigner)
         })
 
@@ -113,7 +113,7 @@ describe('CheqdSigningStargateClient', () => {
             const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
             const verificationMethod: Partial<VerificationMethod> = {
                 id: nonExistingKeyId,
-                type: nonExistingVerificationMethod,
+                verificationMethodType: nonExistingVerificationMethod,
                 controller: nonExistingDid,
                 verificationMaterial: JSON.stringify({publicKeyMultibase: nonExistingPublicKeyMultibase})
             }
@@ -128,8 +128,8 @@ describe('CheqdSigningStargateClient', () => {
             const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
             const keyPair = createKeyPairBase64()
             const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
-            const verificationMethods = createDidVerificationMethod([VerificationMethods.Base58], [verificationKeys])
-            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
+            const didPayload = MsgCreateDidPayload.transformPayload(MsgCreateDidPayload.fromPartial(createDidPayload(verificationMethods, [verificationKeys])))
             const signInputs: ISignInputs[] = [
                 {
                     verificationMethodId: didPayload.verificationMethod[0].id,

--- a/tests/testutils.test.ts
+++ b/tests/testutils.test.ts
@@ -119,12 +119,11 @@ export function createVerificationKeys(keyPair: IKeyPair, algo: MethodSpecificId
                     id: verificationKeys[_].keyId,
                     type,
                     controller: verificationKeys[_].didUrl,
-                    publicKeyJWK: JSON.stringify({
-                            crv: 'Ed25519',
-                            kty: 'OKP',
-                            x: toString( fromString( verificationKeys[_].publicKey, 'base64pad' ), 'base64url' )
-                        }
-                    )
+                    publicKeyJWK: {
+                        crv: 'Ed25519',
+                        kty: 'OKP',
+                        x: toString( fromString( verificationKeys[_].publicKey, 'base64pad' ), 'base64url' )
+                    }
                 }
         }
     }) ?? []

--- a/tests/testutils.test.ts
+++ b/tests/testutils.test.ts
@@ -1,13 +1,11 @@
-import { MsgCreateDidDocPayload, VerificationMethod } from "@cheqd/ts-proto/cheqd/did/v2"
 import { CheqdNetwork, IKeyPair, IVerificationKeys, MethodSpecificIdAlgo, MsgCreateDidPayload, TMethodSpecificId, TVerificationKey, TVerificationKeyPrefix, VerificationMethodPayload, VerificationMethods } from "../src/types"
 import { bases } from 'multiformats/basics'
-import { base58ToBytes, base64ToBytes } from "did-jwt"
+import { base64ToBytes } from "did-jwt"
 import { fromString, toString } from 'uint8arrays'
 import { generateKeyPair, KeyPair } from '@stablelib/ed25519'
 import { GasPrice } from "@cosmjs/stargate"
 import { v4 } from 'uuid'
 import { createHash } from 'crypto'
-import { convertKeyPairtoTImportableEd25519Key } from "../src/utils"
 
 export const faucet = {
     prefix: 'cheqd',

--- a/tests/testutils.test.ts
+++ b/tests/testutils.test.ts
@@ -1,5 +1,5 @@
 import { MsgCreateDidDocPayload, VerificationMethod } from "@cheqd/ts-proto/cheqd/did/v2"
-import { CheqdNetwork, IKeyPair, IVerificationKeys, MethodSpecificIdAlgo, TMethodSpecificId, TVerificationKey, TVerificationKeyPrefix, VerificationMethods } from "../src/types"
+import { CheqdNetwork, IKeyPair, IVerificationKeys, MethodSpecificIdAlgo, MsgCreateDidPayload, TMethodSpecificId, TVerificationKey, TVerificationKeyPrefix, VerificationMethodPayload, VerificationMethods } from "../src/types"
 import { bases } from 'multiformats/basics'
 import { base58ToBytes, base64ToBytes } from "did-jwt"
 import { fromString, toString } from 'uint8arrays'
@@ -21,6 +21,9 @@ export const exampleCheqdNetwork = {
     rpcUrl: 'http://localhost:26657',
     gasPrice: GasPrice.fromString( `50${faucet.minimalDenom}` )
 }
+
+// multicodec ed25519-pub header as varint
+const MULTICODEC_ED25519_PUB_HEADER = new Uint8Array([0xed, 0x01]);
 
 /**
  *? General test utils. Look for src/utils.ts for stable utils exports.
@@ -92,33 +95,36 @@ export function createVerificationKeys(keyPair: IKeyPair, algo: MethodSpecificId
  *? Used for testing purposes.
  ** NOTE: The following utils are stable but subject to change at any given moment.
  */
-export function createDidVerificationMethod(verificationMethodTypes: VerificationMethods[], verificationKeys: IVerificationKeys[]): VerificationMethod[] {
+ export function createDidVerificationMethod(verificationMethodTypes: VerificationMethods[], verificationKeys: IVerificationKeys[]): VerificationMethodPayload[] {
     return verificationMethodTypes.map((type, _) => {
         switch (type) {
-            case VerificationMethods.Base58:
+            case VerificationMethods.Ed255192020:
                 return {
                     id: verificationKeys[_].keyId,
-                    type: type,
+                    type,
                     controller: verificationKeys[_].didUrl,
-                    verificationMaterial: JSON.stringify({
-                        publicKeyMultibase: verificationKeys[_].methodSpecificId,
-                        publicKeyJwk: []
-                    })
+                    publicKeyMultibase: _encodeMbKey(MULTICODEC_ED25519_PUB_HEADER, base64ToBytes(verificationKeys[_].publicKey))
+                }
+            
+            case VerificationMethods.Ed255192018:
+                return {
+                    id: verificationKeys[_].keyId,
+                    type,
+                    controller: verificationKeys[_].didUrl,
+                    publicKeyBase58: verificationKeys[_].methodSpecificId.slice(1)
                 }
 
             case VerificationMethods.JWK:
                 return {
                     id: verificationKeys[_].keyId,
-                    type: type,
+                    type,
                     controller: verificationKeys[_].didUrl,
-                    verificationMaterial: JSON.stringify({
-                        publicKeyJwk: {
+                    publicKeyJWK: JSON.stringify({
                             crv: 'Ed25519',
                             kty: 'OKP',
                             x: toString( fromString( verificationKeys[_].publicKey, 'base64pad' ), 'base64url' )
-                        },
-                        publicKeyMultibase: ''
-                    })
+                        }
+                    )
                 }
         }
     }) ?? []
@@ -129,13 +135,13 @@ export function createDidVerificationMethod(verificationMethodTypes: Verificatio
  *? Used for testing purposes.
  ** NOTE: The following utils are stable but subject to change at any given moment.
  */
-export function createDidPayload(verificationMethods: VerificationMethod[], verificationKeys: IVerificationKeys[]): MsgCreateDidDocPayload {
+export function createDidPayload(verificationMethods: VerificationMethodPayload[], verificationKeys: IVerificationKeys[]): MsgCreateDidPayload {
     if (!verificationMethods || verificationMethods.length === 0)
         throw new Error('No verification methods provided')
     if (!verificationKeys || verificationKeys.length === 0)
         throw new Error('No verification keys provided')
     const did = verificationKeys[0].didUrl
-    return MsgCreateDidDocPayload.fromPartial(
+    return MsgCreateDidPayload.fromPartial(
         {
             id: did,
             controller: verificationKeys.map(key => key.didUrl),
@@ -148,4 +154,13 @@ export function createDidPayload(verificationMethods: VerificationMethod[], veri
 
 function sha256(message: string) {
     return createHash('sha256').update(message).digest('hex')
+  }
+
+  function _encodeMbKey(header: any, key: Uint8Array) {
+    const mbKey = new Uint8Array(header.length + key.length);
+  
+    mbKey.set(header);
+    mbKey.set(key, header.length);
+  
+    return bases['base58btc'].encode(mbKey);
   }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -18,7 +18,7 @@ describe('createSignInputsFromImportableEd25519Key', () => {
         }
 
         const verificationKeys = createVerificationKeys(keyPairBase64, MethodSpecificIdAlgo.Base58, 'key-1', 16)
-        const verificationMethod = createDidVerificationMethod([VerificationMethods.Base58], [verificationKeys])
+        const verificationMethod = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
         const signInput = createSignInputsFromImportableEd25519Key(importableEd25519Key, verificationMethod)
 
         expect(signInput).toEqual({ verificationMethodId: verificationKeys.keyId, privateKeyHex: importableEd25519Key.privateKeyHex })

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -4,7 +4,7 @@ import { toString } from 'uint8arrays'
 import { IKeyPair, MethodSpecificIdAlgo, VerificationMethods } from '../src/types'
 
 describe('createSignInputsFromImportableEd25519Key', () => {
-    it('should create a sign input from an importable ed25519 key', async () => {
+    it('should create a sign input from an importable ed25519 key 2020', async () => {
         const keyPair = createKeyPairRaw()
         const importableEd25519Key: TImportableEd25519Key = {
             publicKeyHex: toString(keyPair.publicKey, 'hex'),
@@ -19,6 +19,26 @@ describe('createSignInputsFromImportableEd25519Key', () => {
 
         const verificationKeys = createVerificationKeys(keyPairBase64, MethodSpecificIdAlgo.Base58, 'key-1', 16)
         const verificationMethod = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
+        const signInput = createSignInputsFromImportableEd25519Key(importableEd25519Key, verificationMethod)
+
+        expect(signInput).toEqual({ verificationMethodId: verificationKeys.keyId, privateKeyHex: importableEd25519Key.privateKeyHex })
+    })
+
+    it('should create a sign input from an importable ed25519 key 2018', async () => {
+        const keyPair = createKeyPairRaw()
+        const importableEd25519Key: TImportableEd25519Key = {
+            publicKeyHex: toString(keyPair.publicKey, 'hex'),
+            privateKeyHex: toString(keyPair.secretKey, 'hex'),
+            kid: toString(keyPair.publicKey, 'hex'),
+            type: 'Ed25519'
+        }
+        const keyPairBase64: IKeyPair = {
+            publicKey: toString(keyPair.publicKey, 'base64'),
+            privateKey: toString(keyPair.secretKey, 'base64'),
+        }
+
+        const verificationKeys = createVerificationKeys(keyPairBase64, MethodSpecificIdAlgo.Base58, 'key-1', 16)
+        const verificationMethod = createDidVerificationMethod([VerificationMethods.Ed255192018], [verificationKeys])
         const signInput = createSignInputsFromImportableEd25519Key(importableEd25519Key, verificationMethod)
 
         expect(signInput).toEqual({ verificationMethodId: verificationKeys.keyId, privateKeyHex: importableEd25519Key.privateKeyHex })


### PR DESCRIPTION
This PR 
-  Updates sdk with the latest ts-proto release
-  Accept user input according to did core spec instead of protobuf encoded json format
- Updated integration tests with updated payload, tests for Ed255192018 and deactivate did
- Completed Support Ed25519VerificationKey2018 in the cheqd/sdk
- Support external signatures to publish txn