### PR TITLE
feat!: On track with v1 on-ledger release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@cheqd/sdk",
-  "version": "1.5.0-develop.1",
+  "version": "1.5.0-develop.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cheqd/sdk",
-      "version": "1.5.0-develop.1",
+      "version": "1.5.0-develop.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cheqd/ts-proto": "^1.0.16-develop.3",
+        "@cheqd/ts-proto": "^2.0.0-develop.1",
         "@cosmjs/amino": "^0.29.4",
         "@cosmjs/encoding": "^0.29.4",
         "@cosmjs/math": "^0.29.4",
@@ -20,6 +20,7 @@
         "@stablelib/ed25519": "^1.0.3",
         "cosmjs-types": "^0.5.2",
         "did-jwt": "^6.9.0",
+        "did-resolver": "^4.0.1",
         "multiformats": "^9.9.0",
         "uuid": "^9.0.0"
       },
@@ -635,9 +636,9 @@
       "dev": true
     },
     "node_modules/@cheqd/ts-proto": {
-      "version": "1.0.16-develop.3",
-      "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-1.0.16-develop.3.tgz",
-      "integrity": "sha512-2CinyDOuCvk8/RXpQyRN8/OHYhvr7JWgJnny/CYz7EoNlxDeK8N/+Bfijncx5bQh4S+Evw9GE0i1vCcwF0wmQQ==",
+      "version": "2.0.0-develop.1",
+      "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-2.0.0-develop.1.tgz",
+      "integrity": "sha512-+dsHyZABC1spbkTjO1dGJOF20sHUumnDIoKGZtrWiu15iIa9vg2IAgKKVyLc7aBs04dxVs/888KN03zAWJvyJQ==",
       "dependencies": {
         "long": "^5.2.1",
         "protobufjs": "~7.1.1"
@@ -10119,9 +10120,9 @@
       "dev": true
     },
     "@cheqd/ts-proto": {
-      "version": "1.0.16-develop.3",
-      "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-1.0.16-develop.3.tgz",
-      "integrity": "sha512-2CinyDOuCvk8/RXpQyRN8/OHYhvr7JWgJnny/CYz7EoNlxDeK8N/+Bfijncx5bQh4S+Evw9GE0i1vCcwF0wmQQ==",
+      "version": "2.0.0-develop.1",
+      "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-2.0.0-develop.1.tgz",
+      "integrity": "sha512-+dsHyZABC1spbkTjO1dGJOF20sHUumnDIoKGZtrWiu15iIa9vg2IAgKKVyLc7aBs04dxVs/888KN03zAWJvyJQ==",
       "requires": {
         "long": "^5.2.1",
         "protobufjs": "~7.1.1"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/cheqd/sdk#readme",
   "dependencies": {
-    "@cheqd/ts-proto": "^1.0.16-develop.3",
+    "@cheqd/ts-proto": "^2.0.0-develop.1",
     "@cosmjs/amino": "^0.29.4",
     "@cosmjs/encoding": "^0.29.4",
     "@cosmjs/math": "^0.29.4",
@@ -37,6 +37,7 @@
     "@stablelib/ed25519": "^1.0.3",
     "cosmjs-types": "^0.5.2",
     "did-jwt": "^6.9.0",
+    "did-resolver": "^4.0.1",
     "multiformats": "^9.9.0",
     "uuid": "^9.0.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,14 @@ import { createDefaultCheqdRegistry } from './registry'
 import { CheqdSigningStargateClient } from './signer'
 import { CheqdNetwork, IContext, IModuleMethodMap } from './types'
 import { createSignInputsFromImportableEd25519Key } from './utils'
+import { GasPrice } from '@cosmjs/stargate'
 
 export interface ICheqdSDKOptions {
 	modules: AbstractCheqdSDKModule[]
-	authorizedMethods?: string[]
-	network?: CheqdNetwork
 	rpcUrl: string
+	network?: CheqdNetwork
+	gasPrice?: GasPrice
+	authorizedMethods?: string[]
 	readonly wallet: OfflineSigner
 }
 
@@ -78,6 +80,7 @@ export class CheqdSDK {
 			this.options.wallet,
             {
                 registry,
+				gasPrice: this.options?.gasPrice,
             }
 		)
 

--- a/src/modules/did.ts
+++ b/src/modules/did.ts
@@ -2,26 +2,41 @@ import { createProtobufRpcClient, DeliverTxResponse, QueryClient } from "@cosmjs
 /* import { QueryClientImpl } from '@cheqd/ts-proto/cheqd/did/v1/query' */
 import { CheqdExtension, AbstractCheqdSDKModule, MinimalImportableCheqdSDKModule } from "./_"
 import { CheqdSigningStargateClient } from "../signer"
-import { DidStdFee, IContext, ISignInputs, MsgCreateDidPayload, MsgDeactivateDidPayload, MsgUpdateDidPayload, VerificationMethodPayload } from "../types"
+import { DIDDocument, DidStdFee, IContext, ISignInputs, SpecValidationResult, VerificationMethods } from '../types';
 import { 
 	MsgCreateDidDoc, 
+	MsgCreateDidDocPayload, 
 	MsgCreateDidDocResponse, 
 	MsgDeactivateDidDoc, 
 	MsgDeactivateDidDocPayload, 
 	MsgDeactivateDidDocResponse, 
 	MsgUpdateDidDoc, 
+	MsgUpdateDidDocPayload, 
 	MsgUpdateDidDocResponse, 
 	protobufPackage, 
-	SignInfo
+	Service, 
+	SignInfo,
+	VerificationMethod
 } from "@cheqd/ts-proto/cheqd/did/v2"
 import { EncodeObject, GeneratedType } from "@cosmjs/proto-signing"
+import { v4 } from "uuid"
+import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
+import { Int53 } from "@cosmjs/math";
 
-export const typeUrlMsgCreateDidDoc = `/${protobufPackage}.MsgCreateDidDoc`
-export const typeUrlMsgCreateDidDocResponse = `/${protobufPackage}.MsgCreateDidDocResponse`
-export const typeUrlMsgUpdateDidDoc = `/${protobufPackage}.MsgUpdateDidDoc`
-export const typeUrlMsgUpdateDidDocResponse = `/${protobufPackage}.MsgUpdateDidDocResponse`
-export const typeUrlMsgDeactivateDidDoc = `/${protobufPackage}.MsgDeactivateDidDoc`
-export const typeUrlMsgDeactivateDidDocResponse = `/${protobufPackage}.MsgDeactivateDidDocResponse`
+export const protobufLiterals = {
+	MsgCreateDidDoc: "MsgCreateDidDoc",
+	MsgCreateDidDocResponse: "MsgCreateDidDocResponse",
+	MsgUpdateDidDoc: "MsgUpdateDidDoc",
+	MsgUpdateDidDocResponse: "MsgUpdateDidDocResponse",
+	MsgDeactivateDidDoc: "MsgDeactivateDidDoc",
+	MsgDeactivateDidDocResponse: "MsgDeactivateDidDocResponse",
+} as const
+export const typeUrlMsgCreateDidDoc = `/${protobufPackage}.${protobufLiterals.MsgCreateDidDoc}`
+export const typeUrlMsgCreateDidDocResponse = `/${protobufPackage}.${protobufLiterals.MsgCreateDidDocResponse}`
+export const typeUrlMsgUpdateDidDoc = `/${protobufPackage}.${protobufLiterals.MsgUpdateDidDoc}`
+export const typeUrlMsgUpdateDidDocResponse = `/${protobufPackage}.${protobufLiterals.MsgUpdateDidDocResponse}`
+export const typeUrlMsgDeactivateDidDoc = `/${protobufPackage}.${protobufLiterals.MsgDeactivateDidDoc}`
+export const typeUrlMsgDeactivateDidDocResponse = `/${protobufPackage}.${protobufLiterals.MsgDeactivateDidDocResponse}`
 
 export interface MsgCreateDidDocEncodeObject extends EncodeObject {
 	readonly typeUrl: typeof typeUrlMsgCreateDidDoc,
@@ -87,6 +102,14 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		[typeUrlMsgDeactivateDidDocResponse, MsgDeactivateDidDocResponse],
     ]
 
+	static readonly baseMinimalDenom = 'ncheq' as const
+
+	static readonly fees = {
+		DefaultCreateDidFee: { amount: '50000000000', denom: DIDModule.baseMinimalDenom } as const,
+		DefaultUpdateDidFee: { amount: '25000000000', denom: DIDModule.baseMinimalDenom } as const,
+		DefaultDeactivateDidFee: { amount: '10000000000', denom: DIDModule.baseMinimalDenom } as const,
+	} as const
+
 	constructor(signer: CheqdSigningStargateClient) {
 		super(signer)
 		this.methods = {
@@ -100,12 +123,36 @@ export class DIDModule extends AbstractCheqdSDKModule {
         return DIDModule.registryTypes
     }
 
-	async createDidTx(signInputs: ISignInputs[] | SignInfo[], didPayload: Partial<MsgCreateDidPayload>, address: string, fee: DidStdFee | 'auto' | number, memo?: string, context?: IContext): Promise<DeliverTxResponse> {
+	async createDidTx(signInputs: ISignInputs[] | SignInfo[], didPayload: DIDDocument, address: string, fee: DidStdFee | 'auto' | number, memo?: string, versionId?: string, context?: IContext): Promise<DeliverTxResponse> {
 		if (!this._signer) {
 			this._signer = context!.sdk!.signer
 		}
 
-		const payload = MsgCreateDidPayload.transformPayload(didPayload)
+		if (!versionId || versionId === '') {
+			versionId = v4()
+		}
+
+		const { valid, error, protobufVerificationMethod, protobufService } = await DIDModule.validateSpecCompliantPayload(didPayload)
+
+		if (!valid) {
+			throw new Error(`DID payload is not spec compliant: ${error}`)
+		}
+
+		const payload = MsgCreateDidDocPayload.fromPartial({
+			context: <string[]>didPayload?.['@context'],
+			id: didPayload.id,
+			controller: <string[]>didPayload.controller,
+			verificationMethod: protobufVerificationMethod,
+			authentication: <string[]>didPayload.authentication,
+			assertionMethod: <string[]>didPayload.assertionMethod,
+			capabilityInvocation: <string[]>didPayload.capabilityInvocation,
+			capabilityDelegation: <string[]>didPayload.capabilityDelegation,
+			keyAgreement: <string[]>didPayload.keyAgreement,
+			service: protobufService,
+			alsoKnownAs: <string[]>didPayload.alsoKnownAs,
+			versionId: versionId
+		})
+
 		let signatures: SignInfo[]
 		if(ISignInputs.isSignInput(signInputs)) {
 			signatures = await this._signer.signCreateDidTx(signInputs, payload)
@@ -131,12 +178,35 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		)
 	}
 
-	async updateDidTx(signInputs: ISignInputs[] | SignInfo[], didPayload: Partial<MsgUpdateDidPayload>, address: string, fee: DidStdFee | 'auto' | number, memo?: string, context?: IContext): Promise<DeliverTxResponse> {
+	async updateDidTx(signInputs: ISignInputs[] | SignInfo[], didPayload: DIDDocument, address: string, fee: DidStdFee | 'auto' | number, memo?: string, versionId?: string, context?: IContext): Promise<DeliverTxResponse> {
 		if (!this._signer) {
 			this._signer = context!.sdk!.signer
 		}
 
-		const payload = MsgCreateDidPayload.transformPayload(didPayload)
+		if (!versionId || versionId === '') {
+			versionId = v4()
+		}
+
+		const { valid, error, protobufVerificationMethod, protobufService } = await DIDModule.validateSpecCompliantPayload(didPayload)
+
+		if (!valid) {
+			throw new Error(`DID payload is not spec compliant: ${error}`)
+		}
+
+		const payload = MsgUpdateDidDocPayload.fromPartial({
+			context: <string[]>didPayload?.['@context'],
+			id: didPayload.id,
+			controller: <string[]>didPayload.controller,
+			verificationMethod: protobufVerificationMethod,
+			authentication: <string[]>didPayload.authentication,
+			assertionMethod: <string[]>didPayload.assertionMethod,
+			capabilityInvocation: <string[]>didPayload.capabilityInvocation,
+			capabilityDelegation: <string[]>didPayload.capabilityDelegation,
+			keyAgreement: <string[]>didPayload.keyAgreement,
+			service: protobufService,
+			alsoKnownAs: <string[]>didPayload.alsoKnownAs,
+			versionId: versionId
+		})
 		let signatures: SignInfo[]
 		if(ISignInputs.isSignInput(signInputs)) {
 			signatures = await this._signer.signUpdateDidTx(signInputs, payload)
@@ -162,15 +232,29 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		)
 	}
 
-	async deactivateDidTx(signInputs: ISignInputs[] | SignInfo[], didPayload: MsgDeactivateDidPayload, address: string, fee: DidStdFee | 'auto' | number, memo?: string, context?: IContext): Promise<DeliverTxResponse> {
+	async deactivateDidTx(signInputs: ISignInputs[] | SignInfo[], didPayload: DIDDocument, address: string, fee: DidStdFee | 'auto' | number, memo?: string, versionId?: string, context?: IContext): Promise<DeliverTxResponse> {
 		if (!this._signer) {
 			this._signer = context!.sdk!.signer
 		}
 
-		const payload = MsgDeactivateDidDocPayload.fromPartial({id: didPayload.id, versionId: didPayload.versionId})
+		if (!versionId || versionId === '') {
+			versionId = v4()
+		}
+
+		const { valid, error, protobufVerificationMethod } = await DIDModule.validateSpecCompliantPayload(didPayload)
+
+		if (!valid) {
+			throw new Error(`DID payload is not spec compliant: ${error}`)
+		}
+
+		const payload = MsgDeactivateDidDocPayload.fromPartial({
+			id: didPayload.id,
+			versionId: versionId
+		})
+
 		let signatures: SignInfo[]
 		if(ISignInputs.isSignInput(signInputs)) {
-			signatures = await this._signer.signDeactivateDidTx(signInputs, payload, didPayload.verificationMethod.map((e)=>VerificationMethodPayload.transformPayload(e)))
+			signatures = await this._signer.signDeactivateDidTx(signInputs, payload, protobufVerificationMethod!)
 		} else {
 			signatures = signInputs
 		}
@@ -191,6 +275,95 @@ export class DIDModule extends AbstractCheqdSDKModule {
 			fee,
 			memo
 		)
+	}
+
+	static async validateSpecCompliantPayload(didDocument: DIDDocument): Promise<SpecValidationResult> {
+		// id is required, validated on both compile and runtime
+		if (!didDocument?.id) return { valid: false, error: 'id is required' }
+
+		// verificationMethod is required
+		if (!didDocument?.verificationMethod) return { valid: false, error: 'verificationMethod is required' }
+
+		// verificationMethod must be an array
+		if (!Array.isArray(didDocument?.verificationMethod)) return { valid: false, error: 'verificationMethod must be an array' }
+
+		// verificationMethod types must be supported
+		const protoVerificationMethod = didDocument.verificationMethod.map((vm) => {
+			switch (vm?.type) {
+				case VerificationMethods.Ed255192020:
+					if (!vm?.publicKeyMultibase) throw new Error('publicKeyMultibase is required')
+
+					return VerificationMethod.fromPartial({
+						id: vm.id,
+						controller: vm.controller,
+						verificationMethodType: VerificationMethods.Ed255192020,
+						verificationMaterial: vm.publicKeyMultibase,
+					})
+				case VerificationMethods.JWK:
+					if (!vm?.publicKeyJwk) throw new Error('publicKeyJwk is required')
+
+					return VerificationMethod.fromPartial({
+						id: vm.id,
+						controller: vm.controller,
+						verificationMethodType: VerificationMethods.JWK,
+						verificationMaterial: JSON.stringify(vm.publicKeyJwk),
+					})
+				case VerificationMethods.Ed255192018:
+					if (!vm?.publicKeyBase58) throw new Error('publicKeyBase58 is required')
+
+					return VerificationMethod.fromPartial({
+						id: vm.id,
+						controller: vm.controller,
+						verificationMethodType: VerificationMethods.Ed255192018,
+						verificationMaterial: vm.publicKeyBase58,
+					})
+				default:
+					throw new Error('Unsupported verificationMethod type')
+			}
+		})
+
+		const protoService = didDocument?.service?.map((s) => {
+			return Service.fromPartial({
+				id: s?.id,
+				serviceType: s?.type,
+				serviceEndpoint: <string[]>s?.serviceEndpoint,
+			})
+		})
+
+		return { valid: true, protobufVerificationMethod: protoVerificationMethod, protobufService: protoService } as SpecValidationResult
+	}
+
+	static async generateCreateDidDocFees(feePayer: string, granter?: string): Promise<DidStdFee> {
+		return {
+			amount: [
+				DIDModule.fees.DefaultCreateDidFee
+			],
+			gas: '360000',
+			payer: feePayer,
+			granter: granter
+		} as DidStdFee
+	}
+
+	static async generateUpdateDidDocFees(feePayer: string, granter?: string): Promise<DidStdFee> {
+		return {
+			amount: [
+				DIDModule.fees.DefaultUpdateDidFee
+			],
+			gas: '360000',
+			payer: feePayer,
+			granter: granter
+		} as DidStdFee
+	}
+
+	static async generateDeactivateDidDocFees(feePayer: string, granter?: string): Promise<DidStdFee> {
+		return {
+			amount: [
+				DIDModule.fees.DefaultDeactivateDidFee
+			],
+			gas: '360000',
+			payer: feePayer,
+			granter: granter
+		} as DidStdFee
 	}
 }
 

--- a/src/modules/resource.ts
+++ b/src/modules/resource.ts
@@ -6,8 +6,13 @@ import { MsgCreateResource, MsgCreateResourcePayload, MsgCreateResourceResponse,
 import { DeliverTxResponse } from "@cosmjs/stargate"
 import { SignInfo } from "@cheqd/ts-proto/cheqd/did/v2";
 
-export const typeUrlMsgCreateResource = `/${protobufPackage}.MsgCreateResource`
-export const typeUrlMsgCreateResourceResponse = `/${protobufPackage}.MsgCreateResourceResponse`
+export const protobufLiterals = {
+	MsgCreateResource: 'MsgCreateResource',
+	MsgCreateResourceResponse: 'MsgCreateResourceResponse'
+} as const
+
+export const typeUrlMsgCreateResource = `/${protobufPackage}.${protobufLiterals.MsgCreateResource}`
+export const typeUrlMsgCreateResourceResponse = `/${protobufPackage}.${protobufLiterals.MsgCreateResourceResponse}`
 
 export interface MsgCreateResourceEncodeObject extends EncodeObject {
 	readonly typeUrl: typeof typeUrlMsgCreateResource,
@@ -23,6 +28,14 @@ export class ResourceModule extends AbstractCheqdSDKModule {
 		[typeUrlMsgCreateResource, MsgCreateResource],
 		[typeUrlMsgCreateResourceResponse, MsgCreateResourceResponse]
 	]
+
+	static readonly baseMinimalDenom = 'ncheq' as const
+
+	static readonly fees = {
+		DefaultCreateResourceImageFee: { amount: '10000000000', denom: ResourceModule.baseMinimalDenom } as const,
+		DefaultCreateResourceJsonFee: { amount: '2500000000', denom: ResourceModule.baseMinimalDenom } as const,
+		DefaultCreateResourceDefaultFee: { amount: '5000000000', denom: ResourceModule.baseMinimalDenom } as const,
+	} as const
 
 	constructor(signer: CheqdSigningStargateClient) {
 		super(signer)
@@ -70,6 +83,39 @@ export class ResourceModule extends AbstractCheqdSDKModule {
 			fee,
 			memo
 		)
+	}
+
+	static async generateCreateResourceImageFees(feePayer: string, granter?: string): Promise<DidStdFee> {
+		return {
+			amount: [
+				ResourceModule.fees.DefaultCreateResourceImageFee
+			],
+			gas: '360000',
+			payer: feePayer,
+			granter: granter
+		} as DidStdFee
+	}
+
+	static async generateCreateResourceJsonFees(feePayer: string, granter?: string): Promise<DidStdFee> {
+		return {
+			amount: [
+				ResourceModule.fees.DefaultCreateResourceJsonFee
+			],
+			gas: '360000',
+			payer: feePayer,
+			granter: granter
+		} as DidStdFee
+	}
+
+	static async generateCreateResourceDefaultFees(feePayer: string, granter?: string): Promise<DidStdFee> {
+		return {
+			amount: [
+				ResourceModule.fees.DefaultCreateResourceDefaultFee
+			],
+			gas: '360000',
+			payer: feePayer,
+			granter: granter
+		} as DidStdFee
 	}
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
+import { Service as ProtobufService, VerificationMethod as ProtobufVerificationMethod } from "@cheqd/ts-proto/cheqd/did/v2"
 import { CheqdSDK } from "."
 import { Coin } from "@cosmjs/proto-signing"
 import { Signer } from "did-jwt"
-import { MsgCreateDidDocPayload, MsgDeactivateDidDocPayload, MsgUpdateDidDocPayload, VerificationMethod, Service } from "@cheqd/ts-proto/cheqd/did/v2"
-import { DeepPartial, Exact } from "cosmjs-types/confio/proofs"
+export { DIDDocument, VerificationMethod, Service, ServiceEndpoint, JsonWebKey } from "did-resolver"
 
 export enum CheqdNetwork {
     Mainnet = 'mainnet',
@@ -17,6 +17,13 @@ export interface IModuleMethodMap extends Record<string, IModuleMethod> {}
 
 export interface IContext {
     sdk: CheqdSDK
+}
+
+export type SpecValidationResult = {
+    valid: boolean
+    error?: string
+    protobufVerificationMethod?: ProtobufVerificationMethod[]
+    protobufService?: ProtobufService[]
 }
 
 export enum VerificationMethods {
@@ -38,12 +45,6 @@ export interface ISignInputs {
     verificationMethodId: string
     keyType?: 'Ed25519' | 'Secp256k1' | 'P256'
     privateKeyHex: string
-}
-
-export const ISignInputs = {
-  isSignInput(object: Object[]): object is ISignInputs[] {
-		return object.some((x)=> 'privateKeyHex' in x)
-	}
 }
 
 export interface IKeyPair {
@@ -77,151 +78,8 @@ export interface DidStdFee {
     granter?: string
 }
 
-export interface MsgDeactivateDidPayload extends MsgDeactivateDidDocPayload {
-    verificationMethod: VerificationMethodPayload[]
-}
-
-export interface MsgCreateDidPayload extends Omit<MsgCreateDidDocPayload, 'verificationMethod' | 'service'> {
-    verificationMethod: VerificationMethodPayload[]
-    service: ServicePayload[]
-}
-
-export const MsgCreateDidPayload = {
-    transformPayload<I extends Exact<DeepPartial<MsgCreateDidPayload>, I>>(message: I): MsgCreateDidDocPayload {
-        const obj: any = {};
-        if (message.context) {
-          obj.context = message.context
-        } else {
-          obj.context = [];
-        }
-        message.id !== undefined && (obj.id = message.id);
-        if (message.controller) {
-          obj.controller = message.controller
-        }
-        if (message.verificationMethod) {
-          obj.verificationMethod = message.verificationMethod.map((e) => e ? VerificationMethodPayload.transformPayload(e) : undefined);
-        }
-        if (message.authentication) {
-          obj.authentication = message.authentication
-        }
-        if (message.assertionMethod) {
-          obj.assertionMethod = message.assertionMethod
-        }
-        if (message.capabilityInvocation) {
-          obj.capabilityInvocation = message.capabilityInvocation
-        }
-        if (message.capabilityDelegation) {
-          obj.capabilityDelegation = message.capabilityDelegation
-        }
-        if (message.keyAgreement) {
-          obj.keyAgreement = message.keyAgreement
-        }
-        if (message.alsoKnownAs) {
-          obj.alsoKnownAs = message.alsoKnownAs
-        }
-        if (message.service) {
-          obj.service = message.service.map((e) => e ? {id: e.id, serviceEndpoint: e.serviceEndpoint, serviceType: e.type} as Service : undefined);
-        }
-        message.versionId !== undefined && (obj.versionId = message.versionId);
-        return MsgCreateDidDocPayload.fromPartial(obj);
-      },
-
-    fromPartial<I extends Exact<DeepPartial<MsgCreateDidPayload>, I>>(object: I): MsgCreateDidPayload {
-        const message = createBaseMsgCreateDidPayload();
-        message.context = object.context?.map((e) => e) || [];
-        message.id = object.id ?? "";
-        message.controller = object.controller?.map((e) => e) || [];
-        message.verificationMethod = object.verificationMethod?.map((e) => VerificationMethodPayload.fromPartial(e)) || [];
-        message.authentication = object.authentication?.map((e) => e) || [];
-        message.assertionMethod = object.assertionMethod?.map((e) => e) || [];
-        message.capabilityInvocation = object.capabilityInvocation?.map((e) => e) || [];
-        message.capabilityDelegation = object.capabilityDelegation?.map((e) => e) || [];
-        message.keyAgreement = object.keyAgreement?.map((e) => e) || [];
-        message.alsoKnownAs = object.alsoKnownAs?.map((e) => e) || [];
-        message.service = object.service?.map((e) => ServicePayload.fromPartial(e)) || [];
-        message.versionId = object.versionId ?? "";
-        return message;
-    },
-    
-}
-
-function createBaseMsgCreateDidPayload(): MsgCreateDidPayload {
-    return {
-      context: [],
-      id: "",
-      controller: [],
-      verificationMethod: [],
-      authentication: [],
-      assertionMethod: [],
-      capabilityInvocation: [],
-      capabilityDelegation: [],
-      keyAgreement: [],
-      alsoKnownAs: [],
-      service: [],
-      versionId: "",
-    };
-  }
-
-export interface VerificationMethodPayload {
-    id: string;
-    type: string;
-    controller: string;
-    publicKeyBase58?: string;
-    publicKeyMultibase?: string;
-    publicKeyJWK?: any;
-}
-
-export const VerificationMethodPayload = {
-    fromPartial<I extends Exact<DeepPartial<VerificationMethodPayload>, I>>(object: I): VerificationMethodPayload {
-        const message = createBaseVerificationMethod();
-        message.id = object.id ?? "";
-        message.type = object.type ?? "";
-        message.controller = object.controller ?? "";
-        if(object.publicKeyMultibase) {
-          message.publicKeyMultibase = object.publicKeyMultibase;
-        } else if (object.publicKeyBase58) {
-          message.publicKeyBase58 = object.publicKeyBase58;
-        } else if (object.publicKeyJWK) {
-          message.publicKeyJWK = object.publicKeyJWK;
-        }
-        return message;
-      },
-    
-    transformPayload<I extends Exact<DeepPartial<VerificationMethodPayload>, I>>(payload: I): VerificationMethod {
-      return {
-        id: payload.id ?? "", 
-        controller: payload.controller ?? "", 
-        verificationMethodType: payload.type ?? "", 
-        verificationMaterial: payload.publicKeyBase58 || payload.publicKeyMultibase || JSON.stringify(payload.publicKeyJWK) || ""
-      } as VerificationMethod
-    }
-}
-
-function createBaseVerificationMethod(): VerificationMethodPayload {
-    return { id: "", type: "", controller: ""  };
-}
-
-export interface ServicePayload {
-    id: string;
-    type: string;
-    serviceEndpoint: string[];
-}
-
-export const ServicePayload = {
-    fromPartial<I extends Exact<DeepPartial<ServicePayload>, I>>(object: I): ServicePayload {
-        const message = createBaseService();
-        message.id = object.id ?? "";
-        message.type = object.type ?? "";
-        message.serviceEndpoint = object.serviceEndpoint?.map((e) => e) || [];
-        return message;
-      },
-}
-
-function createBaseService(): ServicePayload {
-    return { id: "", type: "", serviceEndpoint: [] };
-}
-
-export interface MsgUpdateDidPayload extends Omit<MsgUpdateDidDocPayload, 'verificationMethod' | 'service'> {
-    verificationMethod: VerificationMethodPayload[]
-    service: ServicePayload[]
+export const ISignInputs = {
+  isSignInput(object: Object[]): object is ISignInputs[] {
+		return object.some((x)=> 'privateKeyHex' in x)
+	}
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { DirectSecp256k1HdWallet, GeneratedType } from '@cosmjs/proto-signing'
 import { createCheqdSDK, DIDModule, ICheqdSDKOptions, ResourceModule } from '../src/index'
-import { exampleCheqdNetwork, faucet } from './testutils.test'
+import { localnet, faucet } from './testutils.test'
 import { AbstractCheqdSDKModule } from '../src/modules/_'
 import { CheqdSigningStargateClient } from '../src/signer'
 import { createDefaultCheqdRegistry } from '../src/registry'
@@ -11,7 +11,7 @@ describe(
             it('can be instantiated with modules', async () => {
                 const options = {
                     modules: [DIDModule as unknown as AbstractCheqdSDKModule],
-                    rpcUrl: exampleCheqdNetwork.rpcUrl,
+                    rpcUrl: localnet.rpcUrl,
                     wallet: await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
                 } as ICheqdSDKOptions
                 const cheqdSDK = await createCheqdSDK(options)
@@ -26,7 +26,7 @@ describe(
             })
 
             it('should use module methods', async () => {
-                const rpcUrl = exampleCheqdNetwork.rpcUrl
+                const rpcUrl = localnet.rpcUrl
                 const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
 
                 class TestModule extends AbstractCheqdSDKModule {
@@ -56,7 +56,6 @@ describe(
                 const doSomething = await cheqdSDK.doSomething()
                 expect(doSomething).toBe('did something')
 
-                //@ts-ignore
                 const spy = jest.spyOn(cheqdSDK.methods, 'doSomething')
                 //@ts-ignore
                 await cheqdSDK.doSomething()
@@ -66,7 +65,7 @@ describe(
             it('should instantiate registry from passed modules', async () => {
                 const options = {
                     modules: [DIDModule as unknown as AbstractCheqdSDKModule],
-                    rpcUrl: exampleCheqdNetwork.rpcUrl,
+                    rpcUrl: localnet.rpcUrl,
                     wallet: await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
                 } as ICheqdSDKOptions
                 const cheqdSDK = await createCheqdSDK(options)
@@ -80,7 +79,7 @@ describe(
             it('should instantiate registry from multiple passed modules', async () => {
                 const options = {
                     modules: [DIDModule as unknown as AbstractCheqdSDKModule, ResourceModule as unknown as AbstractCheqdSDKModule],
-                    rpcUrl: exampleCheqdNetwork.rpcUrl,
+                    rpcUrl: localnet.rpcUrl,
                     wallet: await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
                 } as ICheqdSDKOptions
                 const cheqdSDK = await createCheqdSDK(options)

--- a/tests/modules/did.test.ts
+++ b/tests/modules/did.test.ts
@@ -2,12 +2,12 @@ import { MsgUpdateDidDocPayload } from "@cheqd/ts-proto/cheqd/did/v2"
 import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing"
 import { DeliverTxResponse } from "@cosmjs/stargate"
 import { fromString, toString } from 'uint8arrays'
-import { v4 } from "uuid"
 import { DIDModule } from "../../src"
 import { createDefaultCheqdRegistry } from "../../src/registry"
 import { CheqdSigningStargateClient } from "../../src/signer"
-import { DidStdFee, ISignInputs, MethodSpecificIdAlgo, MsgCreateDidPayload, MsgDeactivateDidPayload, VerificationMethods } from "../../src/types"
-import { createDidPayload, createDidVerificationMethod, createKeyPairBase64, createVerificationKeys, exampleCheqdNetwork, faucet } from "../testutils.test"
+import { DIDDocument, ISignInputs, MethodSpecificIdAlgo, VerificationMethods } from "../../src/types"
+import { createDidPayload, createDidVerificationMethod, createKeyPairBase64, createVerificationKeys } from "../../src/utils"
+import { localnet, faucet } from "../testutils.test"
 
 const defaultAsyncTxTimeout = 30000
 
@@ -15,43 +15,36 @@ describe('DIDModule', () => {
     describe('constructor', () => {
         it('should instantiate standalone module', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet)
             const didModule = new DIDModule(signer)
             expect(didModule).toBeInstanceOf(DIDModule)
         })
     })
 
     describe('createDidTx', () => {
-        it('should create a new multibase DID', async () => {
+        it('should create a new multibase DID - case: Ed25519VerificationKey2020', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
             const registry = createDefaultCheqdRegistry(DIDModule.registryTypes)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet, { registry })
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
             const didModule = new DIDModule(signer)
             const keyPair = createKeyPairBase64()
-            const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
-            const verificationMethods = createDidVerificationMethod([VerificationMethods.JWK], [verificationKeys])
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys])
 
             const signInputs: ISignInputs[] = [
                 {
-                    verificationMethodId: didPayload.verificationMethod[0].id,
+                    verificationMethodId: didPayload.verificationMethod![0].id,
                     privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
                 }
             ]
-            const fee: DidStdFee = {
-                amount: [
-                    {
-                        denom: 'ncheq',
-                        amount: '5000000'
-                    }
-                ],
-                gas: '200000',
-                payer: (await wallet.getAccounts())[0].address
-            } 
+
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer) 
             const didTx: DeliverTxResponse = await didModule.createDidTx(
                 signInputs,
                 didPayload,
-                (await wallet.getAccounts())[0].address,
+                feePayer,
                 fee
             )
 
@@ -61,36 +54,149 @@ describe('DIDModule', () => {
             expect(didTx.code).toBe(0)
         }, defaultAsyncTxTimeout)
 
-        it('should create a new uuid DID', async () => {
+        it('should create a new multibase DID - case: Ed25519VerificationKey2018', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
             const registry = createDefaultCheqdRegistry(DIDModule.registryTypes)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet, { registry })
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
             const didModule = new DIDModule(signer)
             const keyPair = createKeyPairBase64()
-            const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Uuid, 'key-1', 16)
-            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192018], [verificationKeys])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys])
-            didPayload.versionId = v4()
+
             const signInputs: ISignInputs[] = [
                 {
-                    verificationMethodId: didPayload.verificationMethod[0].id,
+                    verificationMethodId: didPayload.verificationMethod![0].id,
                     privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
                 }
             ]
-            const fee: DidStdFee = {
-                amount: [
-                    {
-                        denom: 'ncheq',
-                        amount: '5000000'
-                    }
-                ],
-                gas: '200000',
-                payer: (await wallet.getAccounts())[0].address
-            } 
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer) 
             const didTx: DeliverTxResponse = await didModule.createDidTx(
                 signInputs,
                 didPayload,
-                (await wallet.getAccounts())[0].address,
+                feePayer,
+                fee
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(didPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(didTx)}`)
+
+            expect(didTx.code).toBe(0)
+        }, defaultAsyncTxTimeout)
+
+        it('should create a new multibase DID - case: JsonWebKey2020', async () => {
+            const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
+            const registry = createDefaultCheqdRegistry(DIDModule.registryTypes)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
+            const didModule = new DIDModule(signer)
+            const keyPair = createKeyPairBase64()
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.JWK], [verificationKeys])
+            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+
+            const signInputs: ISignInputs[] = [
+                {
+                    verificationMethodId: didPayload.verificationMethod![0].id,
+                    privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
+                }
+            ]
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer) 
+            const didTx: DeliverTxResponse = await didModule.createDidTx(
+                signInputs,
+                didPayload,
+                feePayer,
+                fee
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(didPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(didTx)}`)
+
+            expect(didTx.code).toBe(0)
+        }, defaultAsyncTxTimeout)
+
+        it('should create a new uuid DID - case: Ed25519VerificationKey2020', async () => {
+            const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
+            const registry = createDefaultCheqdRegistry(DIDModule.registryTypes)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
+            const didModule = new DIDModule(signer)
+            const keyPair = createKeyPairBase64()
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Uuid, 'key-1')
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
+            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+            const signInputs: ISignInputs[] = [
+                {
+                    verificationMethodId: didPayload.verificationMethod![0].id,
+                    privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
+                }
+            ]
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer) 
+            const didTx: DeliverTxResponse = await didModule.createDidTx(
+                signInputs,
+                didPayload,
+                feePayer,
+                fee
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(didPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(didTx)}`)
+
+            expect(didTx.code).toBe(0)
+        }, defaultAsyncTxTimeout)
+
+        it('should create a new uuid DID - case: Ed25519VerificationKey2018', async () => {
+            const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
+            const registry = createDefaultCheqdRegistry(DIDModule.registryTypes)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
+            const didModule = new DIDModule(signer)
+            const keyPair = createKeyPairBase64()
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Uuid, 'key-1')
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192018], [verificationKeys])
+            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+            const signInputs: ISignInputs[] = [
+                {
+                    verificationMethodId: didPayload.verificationMethod![0].id,
+                    privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
+                }
+            ]
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer) 
+            const didTx: DeliverTxResponse = await didModule.createDidTx(
+                signInputs,
+                didPayload,
+                feePayer,
+                fee
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(didPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(didTx)}`)
+
+            expect(didTx.code).toBe(0)
+        }, defaultAsyncTxTimeout)
+
+        it('should create a new uuid DID - case: JsonWebKey2020', async () => {
+            const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
+            const registry = createDefaultCheqdRegistry(DIDModule.registryTypes)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
+            const didModule = new DIDModule(signer)
+            const keyPair = createKeyPairBase64()
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Uuid, 'key-1')
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.JWK], [verificationKeys])
+            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+            const signInputs: ISignInputs[] = [
+                {
+                    verificationMethodId: didPayload.verificationMethod![0].id,
+                    privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
+                }
+            ]
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer)
+            const didTx: DeliverTxResponse = await didModule.createDidTx(
+                signInputs,
+                didPayload,
+                feePayer,
                 fee
             )
 
@@ -102,36 +208,28 @@ describe('DIDModule', () => {
     })
 
     describe('updateDidTx', () => {
-        it('should update a DID', async () => {
+        it('should update a DID - case: Ed25519VerificationKey2020', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
             const registry = createDefaultCheqdRegistry(DIDModule.registryTypes)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet, { registry })
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
             const didModule = new DIDModule(signer)
-            
+
             const keyPair = createKeyPairBase64()
-            const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
             const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys])
             const signInputs: ISignInputs[] = [
                 {
-                    verificationMethodId: didPayload.verificationMethod[0].id,
+                    verificationMethodId: didPayload.verificationMethod![0].id,
                     privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
                 }
             ]
-            const fee: DidStdFee = {
-                amount: [
-                    {
-                        denom: 'ncheq',
-                        amount: '5000000'
-                    }
-                ],
-                gas: '200000',
-                payer: (await wallet.getAccounts())[0].address
-            } 
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer) 
             const didTx: DeliverTxResponse = await didModule.createDidTx(
                 signInputs,
                 didPayload,
-                (await wallet.getAccounts())[0].address,
+                feePayer,
                 fee
             )
 
@@ -140,60 +238,167 @@ describe('DIDModule', () => {
 
             expect(didTx.code).toBe(0)
 
-            // Update the DID
-            const updateDidPayload = MsgCreateDidPayload.fromPartial({
-                context: didPayload.context,
+            // update the did document
+            const updateDidPayload = {
+                '@context': didPayload?.['@context'],
                 id: didPayload.id,
                 controller: didPayload.controller,
                 verificationMethod: didPayload.verificationMethod,
                 authentication: didPayload.authentication,
-                assertionMethod: [didPayload.verificationMethod[0].id], // New
+                assertionMethod: [didPayload.verificationMethod![0].id], // <-- This is the only difference
                 versionId: didTx.transactionHash
-            })
+            } as DIDDocument
+
+            const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer)
+            const updateDidTx: DeliverTxResponse = await didModule.updateDidTx(
+                signInputs,
+                updateDidPayload,
+                feePayer,
+                feeUpdate
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(updateDidPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(updateDidTx)}`)
+
+            expect(updateDidTx.code).toBe(0)
+        }, defaultAsyncTxTimeout)
+
+        it('should update a DID - case: Ed25519VerificationKey2018', async () => {
+            const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
+            const registry = createDefaultCheqdRegistry(DIDModule.registryTypes)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
+            const didModule = new DIDModule(signer)
+
+            const keyPair = createKeyPairBase64()
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192018], [verificationKeys])
+            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+            const signInputs: ISignInputs[] = [
+                {
+                    verificationMethodId: didPayload.verificationMethod![0].id,
+                    privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
+                }
+            ]
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer) 
+            const didTx: DeliverTxResponse = await didModule.createDidTx(
+                signInputs,
+                didPayload,
+                feePayer,
+                fee
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(didPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(didTx)}`)
+
+            expect(didTx.code).toBe(0)
+
+            // update the did document
+            const updateDidPayload = {
+                '@context': didPayload?.['@context'],
+                id: didPayload.id,
+                controller: didPayload.controller,
+                verificationMethod: didPayload.verificationMethod,
+                authentication: didPayload.authentication,
+                assertionMethod: [didPayload.verificationMethod![0].id], // <-- This is the only difference
+                versionId: didTx.transactionHash
+            } as DIDDocument
+
+            const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer) 
 
             const updateDidTx: DeliverTxResponse = await didModule.updateDidTx(
                 signInputs,
                 updateDidPayload,
-                (await wallet.getAccounts())[0].address,
+                feePayer,
+                feeUpdate
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(updateDidPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(updateDidTx)}`)
+
+            expect(updateDidTx.code).toBe(0)
+        }, defaultAsyncTxTimeout)
+
+        it('should update a DID - case: JsonWebKey2020', async () => {
+            const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
+            const registry = createDefaultCheqdRegistry(DIDModule.registryTypes)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
+            const didModule = new DIDModule(signer)
+
+            const keyPair = createKeyPairBase64()
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.JWK], [verificationKeys])
+            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+            const signInputs: ISignInputs[] = [
+                {
+                    verificationMethodId: didPayload.verificationMethod![0].id,
+                    privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
+                }
+            ]
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer) 
+            const didTx: DeliverTxResponse = await didModule.createDidTx(
+                signInputs,
+                didPayload,
+                feePayer,
                 fee
             )
 
-            console.warn(updateDidTx)
+            console.warn(`Using payload: ${JSON.stringify(didPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(didTx)}`)
+
+            expect(didTx.code).toBe(0)
+
+            // update the did document
+            const updateDidPayload = {
+                '@context': didPayload?.['@context'],
+                id: didPayload.id,
+                controller: didPayload.controller,
+                verificationMethod: didPayload.verificationMethod,
+                authentication: didPayload.authentication,
+                assertionMethod: [didPayload.verificationMethod![0].id], // <-- This is the only difference
+                versionId: didTx.transactionHash
+            } as DIDDocument
+
+            const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer)
+
+            const updateDidTx: DeliverTxResponse = await didModule.updateDidTx(
+                signInputs,
+                updateDidPayload,
+                feePayer,
+                feeUpdate
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(updateDidPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(updateDidTx)}`)
+
             expect(updateDidTx.code).toBe(0)
         }, defaultAsyncTxTimeout)
     })
 
     describe('deactivateDidTx', () => {
-        it('should deactivate a DID', async () => {
+        it('should deactivate a DID - case: Ed25519VerificationKey2020', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
             const registry = createDefaultCheqdRegistry(DIDModule.registryTypes)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet, { registry })
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
             const didModule = new DIDModule(signer)
-            
+
             const keyPair = createKeyPairBase64()
-            const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
             const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys])
             const signInputs: ISignInputs[] = [
                 {
-                    verificationMethodId: didPayload.verificationMethod[0].id,
+                    verificationMethodId: didPayload.verificationMethod![0].id,
                     privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
                 }
             ]
-            const fee: DidStdFee = {
-                amount: [
-                    {
-                        denom: 'ncheq',
-                        amount: '5000000'
-                    }
-                ],
-                gas: '200000',
-                payer: (await wallet.getAccounts())[0].address
-            } 
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer) 
             const didTx: DeliverTxResponse = await didModule.createDidTx(
                 signInputs,
                 didPayload,
-                (await wallet.getAccounts())[0].address,
+                feePayer,
                 fee
             )
 
@@ -202,21 +407,126 @@ describe('DIDModule', () => {
 
             expect(didTx.code).toBe(0)
 
-            // Update the DID
-            const deactivateDidPayload: MsgDeactivateDidPayload = {
+            // deactivate the did document
+            const deactivateDidPayload = {
                 id: didPayload.id,
                 verificationMethod: didPayload.verificationMethod,
-                versionId: v4()
-            }
+            } as DIDDocument
+
+            const feeDeactivate = await DIDModule.generateDeactivateDidDocFees(feePayer)
 
             const deactivateDidTx: DeliverTxResponse = await didModule.deactivateDidTx(
                 signInputs,
                 deactivateDidPayload,
-                (await wallet.getAccounts())[0].address,
+                feePayer,
+                feeDeactivate
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(deactivateDidPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(deactivateDidTx)}`)
+
+            expect(deactivateDidTx.code).toBe(0)
+        }, defaultAsyncTxTimeout)
+
+        it('should deactivate a DID - case: Ed25519VerificationKey2018', async () => {
+            const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
+            const registry = createDefaultCheqdRegistry(DIDModule.registryTypes)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
+            const didModule = new DIDModule(signer)
+
+            const keyPair = createKeyPairBase64()
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192018], [verificationKeys])
+            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+            const signInputs: ISignInputs[] = [
+                {
+                    verificationMethodId: didPayload.verificationMethod![0].id,
+                    privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
+                }
+            ]
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer) 
+            const didTx: DeliverTxResponse = await didModule.createDidTx(
+                signInputs,
+                didPayload,
+                feePayer,
                 fee
             )
 
-            console.warn(deactivateDidTx)
+            console.warn(`Using payload: ${JSON.stringify(didPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(didTx)}`)
+
+            expect(didTx.code).toBe(0)
+
+            // deactivate the did document
+            const deactivateDidPayload = {
+                id: didPayload.id,
+                verificationMethod: didPayload.verificationMethod,
+            } as DIDDocument
+
+            const feeDeactivate = await DIDModule.generateDeactivateDidDocFees(feePayer)
+
+            const deactivateDidTx: DeliverTxResponse = await didModule.deactivateDidTx(
+                signInputs,
+                deactivateDidPayload,
+                feePayer,
+                feeDeactivate
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(deactivateDidPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(deactivateDidTx)}`)
+
+            expect(deactivateDidTx.code).toBe(0)
+        }, defaultAsyncTxTimeout)
+
+        it('should deactivate a DID - case: JsonWebKey2020', async () => {
+            const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
+            const registry = createDefaultCheqdRegistry(DIDModule.registryTypes)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
+            const didModule = new DIDModule(signer)
+
+            const keyPair = createKeyPairBase64()
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.JWK], [verificationKeys])
+            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+            const signInputs: ISignInputs[] = [
+                {
+                    verificationMethodId: didPayload.verificationMethod![0].id,
+                    privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
+                }
+            ]
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer)
+            const didTx: DeliverTxResponse = await didModule.createDidTx(
+                signInputs,
+                didPayload,
+                feePayer,
+                fee
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(didPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(didTx)}`)
+
+            expect(didTx.code).toBe(0)
+
+            // deactivate the did document
+            const deactivateDidPayload = {
+                id: didPayload.id,
+                verificationMethod: didPayload.verificationMethod,
+            } as DIDDocument
+
+            const feeDeactivate = await DIDModule.generateDeactivateDidDocFees(feePayer)
+
+            const deactivateDidTx: DeliverTxResponse = await didModule.deactivateDidTx(
+                signInputs,
+                deactivateDidPayload,
+                feePayer,
+                feeDeactivate
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(deactivateDidPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(deactivateDidTx)}`)
+
             expect(deactivateDidTx.code).toBe(0)
         }, defaultAsyncTxTimeout)
     })

--- a/tests/modules/resource.test.ts
+++ b/tests/modules/resource.test.ts
@@ -4,10 +4,11 @@ import { fromString, toString } from 'uint8arrays'
 import { DIDModule, ResourceModule } from "../../src"
 import { createDefaultCheqdRegistry } from "../../src/registry"
 import { CheqdSigningStargateClient } from "../../src/signer"
-import { DidStdFee, ISignInputs, MethodSpecificIdAlgo, VerificationMethods } from '../../src/types';
-import { createDidPayload, createDidVerificationMethod, createKeyPairBase64, createVerificationKeys, exampleCheqdNetwork, faucet } from "../testutils.test"
+import { ISignInputs, MethodSpecificIdAlgo, VerificationMethods } from '../../src/types';
+import { createDidPayload, createDidVerificationMethod, createKeyPairBase64, createVerificationKeys } from "../../src/utils"
+import { localnet, faucet, image_content, default_content } from "../testutils.test"
 import { MsgCreateResourcePayload } from '@cheqd/ts-proto/cheqd/resource/v2';
-import { randomUUID } from "crypto"
+import { v4 } from "uuid"
 
 const defaultAsyncTxTimeout = 30000
 
@@ -15,50 +16,41 @@ describe('ResourceModule', () => {
     describe('constructor', () => {
         it('should instantiate standalone module', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet)
             const resourceModule = new ResourceModule(signer)
             expect(resourceModule).toBeInstanceOf(ResourceModule)
         })
     })
 
     describe('createResourceTx', () => {
-        it('should create a new Resource', async () => {
-            // Creating a DID
+        it('should create a new Resource - case: json', async () => {
+            // create an associated did document
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
 
             const registry = createDefaultCheqdRegistry(Array.from(DIDModule.registryTypes).concat(Array.from(ResourceModule.registryTypes)))
 
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet, { registry })
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
             
             const didModule = new DIDModule(signer)
 
             const keyPair = createKeyPairBase64()
-            const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
             const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
             const didPayload = createDidPayload(verificationMethods, [verificationKeys])
 
             const signInputs: ISignInputs[] = [
                 {
-                    verificationMethodId: didPayload.verificationMethod[0].id,
+                    verificationMethodId: didPayload.verificationMethod![0].id,
                     privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
                 }
             ]
 
-            const fee: DidStdFee = {
-                amount: [
-                    {
-                        denom: 'ncheq',
-                        amount: '2500000000'
-                    }
-                ],
-                gas: '200000',
-                payer: (await wallet.getAccounts())[0].address
-            } 
-            
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer)
             const didTx: DeliverTxResponse = await didModule.createDidTx(
                 signInputs,
                 didPayload,
-                (await wallet.getAccounts())[0].address,
+                feePayer,
                 fee
             )
 
@@ -67,37 +59,178 @@ describe('ResourceModule', () => {
 
             expect(didTx.code).toBe(0)
 
-            // Creating a resource
-
+            // create a did linked resource
             const resourceModule = new ResourceModule(signer)
 
             const resourcePayload: MsgCreateResourcePayload = {
                 collectionId: didPayload.id.split(":").reverse()[0],
-                id: randomUUID(),
+                id: v4(),
                 version: "1.0",
                 alsoKnownAs: [],
                 name: 'Test Resource',
                 resourceType: 'test-resource-type',
-                data: new TextEncoder().encode("{ \"message\": \"hello world\"}")
+                data: new TextEncoder().encode("{\"message\": \"hello world\"}")
             }
-
-            console.warn(`Using payload: ${JSON.stringify(resourcePayload)}`)
 
             const resourceSignInputs: ISignInputs[] = [
                 {
-                    verificationMethodId: didPayload.verificationMethod[0].id,
+                    verificationMethodId: didPayload.verificationMethod![0].id,
                     keyType: 'Ed25519',
                     privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
                 }
             ]
 
+            const feeResourceJson = await ResourceModule.generateCreateResourceJsonFees(feePayer)
             const resourceTx = await resourceModule.createResourceTx(
                 resourceSignInputs,
                 resourcePayload,
-                (await wallet.getAccounts())[0].address,
+                feePayer,
+                feeResourceJson
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(resourcePayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(resourceTx)}`)
+
+            expect(resourceTx.code).toBe(0)
+        }, defaultAsyncTxTimeout)
+
+        it('should create a new Resource - case: image', async () => {
+            // create an associated did document
+            const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
+
+            const registry = createDefaultCheqdRegistry(Array.from(DIDModule.registryTypes).concat(Array.from(ResourceModule.registryTypes)))
+
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
+            
+            const didModule = new DIDModule(signer)
+
+            const keyPair = createKeyPairBase64()
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
+            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+
+            const signInputs: ISignInputs[] = [
+                {
+                    verificationMethodId: didPayload.verificationMethod![0].id,
+                    privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
+                }
+            ]
+
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer)
+            const didTx: DeliverTxResponse = await didModule.createDidTx(
+                signInputs,
+                didPayload,
+                feePayer,
                 fee
             )
 
+            console.warn(`Using payload: ${JSON.stringify(didPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(didTx)}`)
+
+            expect(didTx.code).toBe(0)
+
+            // create a did linked resource
+            const resourceModule = new ResourceModule(signer)
+
+            const resourcePayload: MsgCreateResourcePayload = {
+                collectionId: didPayload.id.split(":").reverse()[0],
+                id: v4(),
+                version: "1.0",
+                alsoKnownAs: [],
+                name: 'Test Resource',
+                resourceType: 'test-resource-type',
+                data: fromString(image_content, 'base64')
+            }
+
+            const resourceSignInputs: ISignInputs[] = [
+                {
+                    verificationMethodId: didPayload.verificationMethod![0].id,
+                    keyType: 'Ed25519',
+                    privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
+                }
+            ]
+
+            const feeResourceImage = await ResourceModule.generateCreateResourceImageFees(feePayer)
+            const resourceTx = await resourceModule.createResourceTx(
+                resourceSignInputs,
+                resourcePayload,
+                feePayer,
+                feeResourceImage
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(resourcePayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(resourceTx)}`)
+
+            expect(resourceTx.code).toBe(0)
+        }, defaultAsyncTxTimeout)
+
+        it('should create a new Resource - case: default', async () => {
+            // create an associated did document
+            const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, {prefix: faucet.prefix})
+
+            const registry = createDefaultCheqdRegistry(Array.from(DIDModule.registryTypes).concat(Array.from(ResourceModule.registryTypes)))
+
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
+            
+            const didModule = new DIDModule(signer)
+
+            const keyPair = createKeyPairBase64()
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
+            const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
+            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+
+            const signInputs: ISignInputs[] = [
+                {
+                    verificationMethodId: didPayload.verificationMethod![0].id,
+                    privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
+                }
+            ]
+
+            const feePayer = (await wallet.getAccounts())[0].address
+            const fee = await DIDModule.generateCreateDidDocFees(feePayer)
+            const didTx: DeliverTxResponse = await didModule.createDidTx(
+                signInputs,
+                didPayload,
+                feePayer,
+                fee
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(didPayload)}`)
+            console.warn(`DID Tx: ${JSON.stringify(didTx)}`)
+
+            expect(didTx.code).toBe(0)
+
+            // create a did linked resource
+            const resourceModule = new ResourceModule(signer)
+
+            const resourcePayload: MsgCreateResourcePayload = {
+                collectionId: didPayload.id.split(":").reverse()[0],
+                id: v4(),
+                version: "1.0",
+                alsoKnownAs: [],
+                name: 'Test Resource',
+                resourceType: 'test-resource-type',
+                data: new TextEncoder().encode(default_content)
+            }
+
+            const resourceSignInputs: ISignInputs[] = [
+                {
+                    verificationMethodId: didPayload.verificationMethod![0].id,
+                    keyType: 'Ed25519',
+                    privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
+                }
+            ]
+
+            const feeResourceDefault = await ResourceModule.generateCreateResourceDefaultFees(feePayer)
+            const resourceTx = await resourceModule.createResourceTx(
+                resourceSignInputs,
+                resourcePayload,
+                feePayer,
+                feeResourceDefault
+            )
+
+            console.warn(`Using payload: ${JSON.stringify(resourcePayload)}`)
             console.warn(`DID Tx: ${JSON.stringify(resourceTx)}`)
 
             expect(resourceTx.code).toBe(0)

--- a/tests/signer.test.ts
+++ b/tests/signer.test.ts
@@ -3,10 +3,12 @@ import { DirectSecp256k1HdWallet, Registry } from "@cosmjs/proto-signing"
 import { EdDSASigner } from "did-jwt"
 import { typeUrlMsgCreateDidDoc } from '../src/modules/did'
 import { CheqdSigningStargateClient } from "../src/signer"
-import { ISignInputs, MethodSpecificIdAlgo, MsgCreateDidPayload, VerificationMethods } from "../src/types"
+import { ISignInputs, MethodSpecificIdAlgo, VerificationMethods } from "../src/types"
 import { fromString, toString } from 'uint8arrays'
-import { createDidPayload, createDidVerificationMethod, createKeyPairBase64, createVerificationKeys, exampleCheqdNetwork, faucet } from "./testutils.test"
+import { createDidPayload, createDidVerificationMethod, createKeyPairBase64, createVerificationKeys, validateSpecCompliantPayload } from '../src/utils';
+import { localnet, faucet } from "./testutils.test"
 import { verify } from "@stablelib/ed25519"
+import { v4 } from "uuid"
 
 const nonExistingDid = "did:cHeQd:fantasticnet:123"
 const nonExistingKeyId = 'did:cHeQd:fantasticnet:123#key-678'
@@ -34,7 +36,7 @@ describe('CheqdSigningStargateClient', () => {
     describe('constructor', () => {
         it('can be instantiated & works for cheqd networks', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet)
             expect(signer).toBeInstanceOf(CheqdSigningStargateClient)
         })
 
@@ -42,7 +44,7 @@ describe('CheqdSigningStargateClient', () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
             const registry = new Registry()
             registry.register(typeUrlMsgCreateDidDoc, MsgCreateDidDoc)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet, { registry })
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, { registry })
             expect(signer.registry.lookupType(typeUrlMsgCreateDidDoc)).toBe(MsgCreateDidDoc)
         })
     })
@@ -50,61 +52,67 @@ describe('CheqdSigningStargateClient', () => {
     describe('getDidSigner', () => {
         it('can get a signer for a did', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet)
             const keyPair = createKeyPairBase64()
-            const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
             const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
-            const didPayload = MsgCreateDidPayload.transformPayload(createDidPayload(verificationMethods, [verificationKeys]))
-            const didSigner = await signer.getDidSigner(didPayload.verificationMethod[0].id, didPayload.verificationMethod)
+            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
+            const { protobufVerificationMethod } = validateSpecCompliantPayload(didPayload)
+
+            const didSigner = await signer.getDidSigner(didPayload.verificationMethod![0].id, protobufVerificationMethod!)
 
             expect(didSigner).toBe(EdDSASigner)
         })
 
         it('should throw for a non-supported verification method', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet)
 
             await expect(signer.getDidSigner(nonExistingVerificationDidDocument.verificationMethod[0].id, nonExistingVerificationDidDocument.verificationMethod)).rejects.toThrow()
         })
 
         it('should throw for non-matching verification method id', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet)
             const keyPair = createKeyPairBase64()
-            const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
             const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
-            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
-            await expect(signer.getDidSigner(nonExistingKeyId, didPayload.verificationMethod)).rejects.toThrow()
+            const payload = createDidPayload(verificationMethods, [verificationKeys])
+            const { protobufVerificationMethod } = validateSpecCompliantPayload(payload)
+
+            await expect(signer.getDidSigner(nonExistingKeyId, protobufVerificationMethod!)).rejects.toThrow()
         })
     })
 
     describe('checkDidSigners', () => {
         it('it should instantiate a signer for a did', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet)
             const keyPair = createKeyPairBase64()
-            const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
             const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
-            const didPayload = MsgCreateDidPayload.transformPayload(createDidPayload(verificationMethods, [verificationKeys]))
-
-            const didSigners = await signer.checkDidSigners(didPayload.verificationMethod)
+            const payload = createDidPayload(verificationMethods, [verificationKeys])
+            const { protobufVerificationMethod } = validateSpecCompliantPayload(payload)
+            const didSigners = await signer.checkDidSigners(protobufVerificationMethod)
 
             expect(didSigners[VerificationMethods.Ed255192020]).toBe(EdDSASigner)
         })
 
         it('should instantiate multiple signers for a did with multiple verification methods', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet)
             const keyPair1 = createKeyPairBase64()
             const keyPair2 = createKeyPairBase64()
             const keyPair3 = createKeyPairBase64()
-            const verificationKeys1 = createVerificationKeys(keyPair1, MethodSpecificIdAlgo.Base58, 'key-1', 16)
-            const verificationKeys2 = createVerificationKeys(keyPair2, MethodSpecificIdAlgo.Base58, 'key-2', 16)
-            const verificationKeys3 = createVerificationKeys(keyPair3, MethodSpecificIdAlgo.Base58, 'key-3', 16)
+            const verificationKeys1 = createVerificationKeys(keyPair1.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
+            const verificationKeys2 = createVerificationKeys(keyPair2.publicKey, MethodSpecificIdAlgo.Base58, 'key-2')
+            const verificationKeys3 = createVerificationKeys(keyPair3.publicKey, MethodSpecificIdAlgo.Base58, 'key-3')
             const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020, VerificationMethods.JWK, VerificationMethods.Ed255192018], [verificationKeys1, verificationKeys2, verificationKeys3])
-            const didPayload = MsgCreateDidPayload.transformPayload(createDidPayload(verificationMethods, [verificationKeys1, verificationKeys2, verificationKeys3]))
 
-            const didSigners = await signer.checkDidSigners(didPayload.verificationMethod)
+            const payload = createDidPayload(verificationMethods, [verificationKeys1, verificationKeys2, verificationKeys3])
+            const { protobufVerificationMethod } = validateSpecCompliantPayload(payload)
+
+            const didSigners = await signer.checkDidSigners(protobufVerificationMethod)
 
             expect(didSigners[VerificationMethods.Ed255192020]).toBe(EdDSASigner)
             expect(didSigners[VerificationMethods.JWK]).toBe(EdDSASigner)
@@ -113,7 +121,7 @@ describe('CheqdSigningStargateClient', () => {
 
         it('should throw for non-supported verification method', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet)
             const verificationMethod: Partial<VerificationMethod> = {
                 id: nonExistingKeyId,
                 verificationMethodType: nonExistingVerificationMethod,
@@ -128,20 +136,36 @@ describe('CheqdSigningStargateClient', () => {
     describe('signCreateDidTx', () => {
         it('should sign a did tx with valid signature', async () => {
             const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic)
-            const signer = await CheqdSigningStargateClient.connectWithSigner(exampleCheqdNetwork.rpcUrl, wallet)
+            const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet)
             const keyPair = createKeyPairBase64()
-            const verificationKeys = createVerificationKeys(keyPair, MethodSpecificIdAlgo.Base58, 'key-1', 16)
+            const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
             const verificationMethods = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
-            const didPayload = MsgCreateDidPayload.transformPayload(MsgCreateDidPayload.fromPartial(createDidPayload(verificationMethods, [verificationKeys])))
+            const didPayload = createDidPayload(verificationMethods, [verificationKeys])
             const signInputs: ISignInputs[] = [
                 {
-                    verificationMethodId: didPayload.verificationMethod[0].id,
+                    verificationMethodId: didPayload.verificationMethod![0].id,
                     privateKeyHex: toString(fromString(keyPair.privateKey, 'base64'), 'hex')
                 }
             ]
-            const signInfos = await signer.signCreateDidTx(signInputs, didPayload)
+            const { protobufVerificationMethod, protobufService } = validateSpecCompliantPayload(didPayload)
+            const versionId = v4()
+            const payload = MsgCreateDidDocPayload.fromPartial({
+                context: <string[]>didPayload?.['@context'],
+                id: didPayload.id,
+                controller: <string[]>didPayload.controller,
+                verificationMethod: protobufVerificationMethod,
+                authentication: <string[]>didPayload.authentication,
+                assertionMethod: <string[]>didPayload.assertionMethod,
+                capabilityInvocation: <string[]>didPayload.capabilityInvocation,
+                capabilityDelegation: <string[]>didPayload.capabilityDelegation,
+                keyAgreement: <string[]>didPayload.keyAgreement,
+                service: protobufService,
+                alsoKnownAs: <string[]>didPayload.alsoKnownAs,
+                versionId: versionId
+            })
+            const signInfos = await signer.signCreateDidTx(signInputs, payload)
             const publicKeyRaw = fromString(keyPair.publicKey, 'base64')
-            const messageRaw = MsgCreateDidDocPayload.encode(didPayload).finish()
+            const messageRaw = MsgCreateDidDocPayload.encode(payload).finish()
 
             const verified = verify(
                 publicKeyRaw,

--- a/tests/testutils.test.ts
+++ b/tests/testutils.test.ts
@@ -9,7 +9,7 @@ export const faucet = {
 
 export const localnet = {
     network: 'testnet',
-    rpcUrl: 'https://rpc.cheqd.network',
+    rpcUrl: 'http://localhost:26657',
     gasPrice: GasPrice.fromString( `50${faucet.minimalDenom}` )
 }
 

--- a/tests/testutils.test.ts
+++ b/tests/testutils.test.ts
@@ -1,11 +1,4 @@
-import { CheqdNetwork, IKeyPair, IVerificationKeys, MethodSpecificIdAlgo, MsgCreateDidPayload, TMethodSpecificId, TVerificationKey, TVerificationKeyPrefix, VerificationMethodPayload, VerificationMethods } from "../src/types"
-import { bases } from 'multiformats/basics'
-import { base64ToBytes } from "did-jwt"
-import { fromString, toString } from 'uint8arrays'
-import { generateKeyPair, KeyPair } from '@stablelib/ed25519'
 import { GasPrice } from "@cosmjs/stargate"
-import { v4 } from 'uuid'
-import { createHash } from 'crypto'
 
 export const faucet = {
     prefix: 'cheqd',
@@ -14,150 +7,12 @@ export const faucet = {
     address: 'cheqd1rnr5jrt4exl0samwj0yegv99jeskl0hsxmcz96',
 }
 
-export const exampleCheqdNetwork = {
+export const localnet = {
     network: 'testnet',
-    rpcUrl: 'http://localhost:26657',
+    rpcUrl: 'https://rpc.cheqd.network',
     gasPrice: GasPrice.fromString( `50${faucet.minimalDenom}` )
 }
 
-// multicodec ed25519-pub header as varint
-const MULTICODEC_ED25519_PUB_HEADER = new Uint8Array([0xed, 0x01]);
+export const image_content = 'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAAQMAAABmvDolAAAAA1BMVEW10NBjBBbqAAAAH0lEQVRoge3BAQ0AAADCoPdPbQ43oAAAAAAAAAAAvg0hAAABmmDh1QAAAABJRU5ErkJggg' as const
 
-/**
- *? General test utils. Look for src/utils.ts for stable utils exports.
- *? Used for testing purposes.
- ** NOTE: The following utils are stable but subject to change at any given moment.
- */
-export function createKeyPairRaw(): KeyPair {
-    return generateKeyPair()
-}
-
-/**
- *? General test utils. Look for src/utils.ts for stable utils exports.
- *? Used for testing purposes.
- ** NOTE: The following utils are stable but subject to change at any given moment.
- */
-export function createKeyPairBase64(): IKeyPair {
-    const keyPair = generateKeyPair()
-    return {
-        publicKey: toString(keyPair.publicKey, 'base64'),
-        privateKey: toString(keyPair.secretKey, 'base64'),
-    }
-}
-
-/**
- *? General test utils. Look for src/utils.ts for stable utils exports.
- *? Used for testing purposes.
- ** NOTE: The following utils are stable but subject to change at any given moment.
- */
-export function createKeyPairHex(): IKeyPair {
-    const keyPair = generateKeyPair()
-    return {
-        publicKey: toString(keyPair.publicKey, 'hex'),
-        privateKey: toString(keyPair.secretKey, 'hex'),
-    }
-}
-
-/**
- *? General test utils. Look for src/utils.ts for stable utils exports.
- *? Used for testing purposes.
- ** NOTE: The following utils are stable but subject to change at any given moment.
- */
-export function createVerificationKeys(keyPair: IKeyPair, algo: MethodSpecificIdAlgo, key: TVerificationKey<TVerificationKeyPrefix, number>, length: number = 32, network: CheqdNetwork = CheqdNetwork.Testnet): IVerificationKeys {
-    let methodSpecificId: TMethodSpecificId
-    let didUrl: IVerificationKeys['didUrl']
-    switch (algo) {
-        case MethodSpecificIdAlgo.Base58:
-            methodSpecificId = bases['base58btc'].encode(base64ToBytes(keyPair.publicKey))
-            didUrl = `did:cheqd:${network}:${(bases['base58btc'].encode((fromString(sha256(keyPair.publicKey))).slice(0,16))).slice(1)}`
-            return {
-                methodSpecificId,
-                didUrl,
-                keyId: `${didUrl}#${key}`,
-                publicKey: keyPair.publicKey,
-            }
-        case MethodSpecificIdAlgo.Uuid:
-            methodSpecificId = bases['base58btc'].encode(base64ToBytes(keyPair.publicKey))
-            didUrl = `did:cheqd:${network}:${v4()}`
-            return {
-                methodSpecificId,
-                didUrl,
-                keyId: `${didUrl}#${key}`,
-                publicKey: keyPair.publicKey,
-            }
-    }
-}
-
-/**
- *? General test utils. Look for src/utils.ts for stable utils exports.
- *? Used for testing purposes.
- ** NOTE: The following utils are stable but subject to change at any given moment.
- */
- export function createDidVerificationMethod(verificationMethodTypes: VerificationMethods[], verificationKeys: IVerificationKeys[]): VerificationMethodPayload[] {
-    return verificationMethodTypes.map((type, _) => {
-        switch (type) {
-            case VerificationMethods.Ed255192020:
-                return {
-                    id: verificationKeys[_].keyId,
-                    type,
-                    controller: verificationKeys[_].didUrl,
-                    publicKeyMultibase: _encodeMbKey(MULTICODEC_ED25519_PUB_HEADER, base64ToBytes(verificationKeys[_].publicKey))
-                }
-            
-            case VerificationMethods.Ed255192018:
-                return {
-                    id: verificationKeys[_].keyId,
-                    type,
-                    controller: verificationKeys[_].didUrl,
-                    publicKeyBase58: verificationKeys[_].methodSpecificId.slice(1)
-                }
-
-            case VerificationMethods.JWK:
-                return {
-                    id: verificationKeys[_].keyId,
-                    type,
-                    controller: verificationKeys[_].didUrl,
-                    publicKeyJWK: {
-                        crv: 'Ed25519',
-                        kty: 'OKP',
-                        x: toString( fromString( verificationKeys[_].publicKey, 'base64pad' ), 'base64url' )
-                    }
-                }
-        }
-    }) ?? []
-}
-
-/**
- *? General test utils. Look for src/utils.ts for stable utils exports.
- *? Used for testing purposes.
- ** NOTE: The following utils are stable but subject to change at any given moment.
- */
-export function createDidPayload(verificationMethods: VerificationMethodPayload[], verificationKeys: IVerificationKeys[]): MsgCreateDidPayload {
-    if (!verificationMethods || verificationMethods.length === 0)
-        throw new Error('No verification methods provided')
-    if (!verificationKeys || verificationKeys.length === 0)
-        throw new Error('No verification keys provided')
-    const did = verificationKeys[0].didUrl
-    return MsgCreateDidPayload.fromPartial(
-        {
-            id: did,
-            controller: verificationKeys.map(key => key.didUrl),
-            verificationMethod: verificationMethods,
-            authentication: verificationKeys.map(key => key.keyId),
-            versionId: v4()
-        }
-    )
-}
-
-function sha256(message: string) {
-    return createHash('sha256').update(message).digest('hex')
-  }
-
-  function _encodeMbKey(header: any, key: Uint8Array) {
-    const mbKey = new Uint8Array(header.length + key.length);
-  
-    mbKey.set(header);
-    mbKey.set(key, header.length);
-  
-    return bases['base58btc'].encode(mbKey);
-  }
+export const default_content = '<p>Test file content</p>'

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { TImportableEd25519Key, createSignInputsFromImportableEd25519Key } from '../src/utils'
-import { createDidVerificationMethod, createVerificationKeys, createKeyPairRaw } from './testutils.test'
+import { createDidVerificationMethod, createVerificationKeys, createKeyPairRaw } from '../src/utils'
 import { toString } from 'uint8arrays'
 import { IKeyPair, MethodSpecificIdAlgo, VerificationMethods } from '../src/types'
 
@@ -17,7 +17,7 @@ describe('createSignInputsFromImportableEd25519Key', () => {
             privateKey: toString(keyPair.secretKey, 'base64'),
         }
 
-        const verificationKeys = createVerificationKeys(keyPairBase64, MethodSpecificIdAlgo.Base58, 'key-1', 16)
+        const verificationKeys = createVerificationKeys(keyPairBase64.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
         const verificationMethod = createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys])
         const signInput = createSignInputsFromImportableEd25519Key(importableEd25519Key, verificationMethod)
 
@@ -37,7 +37,7 @@ describe('createSignInputsFromImportableEd25519Key', () => {
             privateKey: toString(keyPair.secretKey, 'base64'),
         }
 
-        const verificationKeys = createVerificationKeys(keyPairBase64, MethodSpecificIdAlgo.Base58, 'key-1', 16)
+        const verificationKeys = createVerificationKeys(keyPairBase64.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
         const verificationMethod = createDidVerificationMethod([VerificationMethods.Ed255192018], [verificationKeys])
         const signInput = createSignInputsFromImportableEd25519Key(importableEd25519Key, verificationMethod)
 
@@ -57,7 +57,7 @@ describe('createSignInputsFromImportableEd25519Key', () => {
             privateKey: toString(keyPair.secretKey, 'base64'),
         }
 
-        const verificationKeys = createVerificationKeys(keyPairBase64, MethodSpecificIdAlgo.Base58, 'key-1', 16)
+        const verificationKeys = createVerificationKeys(keyPairBase64.publicKey, MethodSpecificIdAlgo.Base58, 'key-1')
         const verificationMethod = createDidVerificationMethod([VerificationMethods.JWK], [verificationKeys])
         const signInput = createSignInputsFromImportableEd25519Key(importableEd25519Key, verificationMethod)
 


### PR DESCRIPTION
- Aligns input to DID-core spec compliant payloads.
- Utilises v2 Protobuf definitions.
- Adds fixed fees.
- Enables setting `gasPrice` for standard Cosmos SDK transactions.
- Handles version id internally & as optional.
- Fixes existing tests.
- Adds more tests in-line with v1 on-ledger release.