### PR TITLE
build: Add @cosmjs/crypto direct dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.2.0-develop.1](https://github.com/cheqd/sdk/compare/3.1.2-develop.1...3.2.0-develop.1) (2023-03-09)
+
+
+### Features
+
+* Update @cheqd/ts-proto from 3.1.2 to 3.1.3 ([#151](https://github.com/cheqd/sdk/issues/151)) ([f6ac275](https://github.com/cheqd/sdk/commit/f6ac2759255ed612a99aff35d497468ff4530e11))
+
 ## [3.1.2-develop.1](https://github.com/cheqd/sdk/compare/3.1.1...3.1.2-develop.1) (2023-03-09)
 
 ## [3.1.1](https://github.com/cheqd/sdk/compare/3.1.0...3.1.1) (2023-02-28)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@cheqd/sdk",
-  "version": "3.1.2-develop.1",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cheqd/sdk",
-      "version": "3.1.2-develop.1",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cheqd/ts-proto": "^3.1.3",
         "@cosmjs/amino": "^0.29.5",
+        "@cosmjs/crypto": "^0.29.5",
         "@cosmjs/encoding": "^0.29.5",
         "@cosmjs/math": "^0.29.5",
         "@cosmjs/proto-signing": "^0.29.5",
@@ -666,6 +667,7 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -2551,6 +2553,7 @@
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
       "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cheqd/sdk",
-  "version": "3.1.2-develop.1",
+  "version": "3.2.0-develop.1",
   "description": "A TypeScript SDK built with CosmJS to interact with cheqd network ledger",
   "license": "Apache-2.0",
   "author": "Cheqd Foundation Limited (https://github.com/cheqd)",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@cosmjs/stargate": "^0.29.5",
     "@cosmjs/tendermint-rpc": "^0.29.5",
     "@cosmjs/utils": "^0.29.5",
+    "@cosmjs/crypto": "^0.29.5",
     "@stablelib/ed25519": "^1.0.3",
     "cosmjs-types": "^0.5.2",
     "did-jwt": "^6.11.2",


### PR DESCRIPTION
@cosmjs/crypto library is used directly in utils.ts, calling the sha256 function. It should be a direct dependency