### PR TITLE
test: Update test runners to use latest stable release of cheqd-node [DEV-4857]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
 
   integration-tests:
     name: "Integration Tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build
 
     steps:
@@ -48,7 +48,7 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
 
       - name: Start cheqd localnet
-        run: docker run --rm -d -p 26657:26657 ghcr.io/cheqd/cheqd-node:3.1.5
+        run: docker run --rm -d -p 26657:26657 ghcr.io/cheqd/cheqd-node:latest
 
       - name: "Clean install dependencies"
         run: npm ci
@@ -58,7 +58,7 @@ jobs:
 
   import-tests:
     name: "Import Tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build
 
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: amannn/action-semantic-pull-request@v5.5.3
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: "Obtain Github App token"
         id: app-token
-        uses: getsentry/action-github-app-token@v3.0.0
+        uses: getsentry/action-github-app-token@v3
         with:
           app_id: ${{ secrets.BOT_APP_ID }}
           private_key: ${{ secrets.BOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
I noticed that the workflows are hardcoded to use node v3.1.5, which is probably a bad idea because we actually changed things at the ledger layer, which aren’t getting tested against!