### PR TITLE
feat: Add signer options to intialize sdk [DEV-5040]

### DIFF
--- a/cjs/src/index.ts
+++ b/cjs/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from './modules/_';
 import { createDefaultCheqdRegistry } from './registry';
 import { CheqdSigningStargateClient } from './signer';
-import { CheqdNetwork, IContext, IModuleMethodMap } from './types';
+import { CheqdNetwork, CheqdSigningStargateClientOptions, IContext, IModuleMethodMap } from './types';
 import { GasPrice, QueryClient } from '@cosmjs/stargate-cjs';
 import { CheqdQuerier } from './querier';
 import { Tendermint37Client } from '@cosmjs/tendermint-rpc-cjs';
@@ -33,6 +33,7 @@ export interface ICheqdSDKOptions {
 	network?: CheqdNetwork;
 	gasPrice?: GasPrice;
 	authorizedMethods?: string[];
+	signerOptions?: CheqdSigningStargateClientOptions;
 	readonly wallet: OfflineSigner;
 }
 
@@ -62,7 +63,7 @@ export class CheqdSDK {
 		};
 
 		this.methods = {};
-		this.signer = new CheqdSigningStargateClient(undefined, this.options.wallet, {});
+		this.signer = new CheqdSigningStargateClient(undefined, this.options.wallet, this.options.signerOptions);
 		this.querier = <any>new QueryClient({} as unknown as Tendermint37Client);
 	}
 

--- a/cjs/src/types.ts
+++ b/cjs/src/types.ts
@@ -5,7 +5,7 @@ import {
 import { CheqdSDK } from './index';
 import { Coin, EncodeObject } from '@cosmjs/proto-signing-cjs';
 import { Signer } from 'did-jwt-cjs';
-import { QueryClient } from '@cosmjs/stargate-cjs';
+import { QueryClient, SigningStargateClientOptions } from '@cosmjs/stargate-cjs';
 import { DIDDocument, DIDResolutionResult } from 'did-resolver-cjs';
 import { DidExtension } from './modules/did';
 import { ResourceExtension } from './modules/resource';
@@ -14,6 +14,7 @@ import { FeeabstractionExtension } from './modules/feeabstraction';
 import { GetTxResponse, SimulateResponse } from 'cosmjs-types-cjs/cosmos/tx/v1beta1/service';
 import { Any } from 'cosmjs-types-cjs/google/protobuf/any';
 import { Pubkey } from '@cosmjs/amino-cjs';
+
 export { DIDDocument, VerificationMethod, Service, ServiceEndpoint, JsonWebKey } from 'did-resolver-cjs';
 
 export enum CheqdNetwork {
@@ -37,8 +38,8 @@ export interface TxExtension {
 			memo: string | undefined,
 			signer: Pubkey,
 			signerAddress: string,
-			sequence: number,
-			gasLimit: number
+			gasLimit: number,
+			sequence?: number
 		) => Promise<SimulateResponse>;
 	};
 }
@@ -137,3 +138,9 @@ export const ISignInputs = {
 export enum ServiceType {
 	LinkedDomains = 'LinkedDomains',
 }
+
+export type CheqdSigningStargateClientOptions = SigningStargateClientOptions & {
+	endpoint?: string;
+	simulateSequence?: boolean;
+	gasMultiplier?: number;
+};

--- a/esm/src/index.ts
+++ b/esm/src/index.ts
@@ -16,7 +16,7 @@ import {
 } from './modules/_.js';
 import { createDefaultCheqdRegistry } from './registry.js';
 import { CheqdSigningStargateClient } from './signer.js';
-import { CheqdNetwork, IContext, IModuleMethodMap } from './types.js';
+import { CheqdNetwork, CheqdSigningStargateClientOptions, IContext, IModuleMethodMap } from './types.js';
 import { GasPrice, QueryClient } from '@cosmjs/stargate';
 import { CheqdQuerier } from './querier.js';
 import { CometClient } from '@cosmjs/tendermint-rpc';
@@ -33,6 +33,7 @@ export interface ICheqdSDKOptions {
 	network?: CheqdNetwork;
 	gasPrice?: GasPrice;
 	authorizedMethods?: string[];
+	signerOptions?: CheqdSigningStargateClientOptions;
 	readonly wallet: OfflineSigner;
 }
 
@@ -62,7 +63,7 @@ export class CheqdSDK {
 		};
 
 		this.methods = {};
-		this.signer = new CheqdSigningStargateClient(undefined, this.options.wallet, {});
+		this.signer = new CheqdSigningStargateClient(undefined, this.options.wallet, this.options.signerOptions);
 		this.querier = <any>new QueryClient({} as unknown as CometClient);
 	}
 

--- a/esm/src/signer.ts
+++ b/esm/src/signer.ts
@@ -381,8 +381,8 @@ export class CheqdSigningStargateClient extends SigningStargateClient {
 					memo: string | undefined,
 					signer: Pubkey,
 					signerAddress: string,
-					sequence: number,
-					gasLimit: number
+					gasLimit: number,
+					sequence?: number
 				): Promise<SimulateResponse> => {
 					// encode public key
 					const publicKey = encodePubkey(signer);
@@ -408,7 +408,7 @@ export class CheqdSigningStargateClient extends SigningStargateClient {
 									modeInfo: {
 										single: { mode: SignMode.SIGN_MODE_DIRECT },
 									},
-									sequence: BigInt(sequence),
+									sequence: sequence ? BigInt(sequence) : undefined,
 								},
 							],
 						}),

--- a/esm/src/types.ts
+++ b/esm/src/types.ts
@@ -5,7 +5,7 @@ import {
 import { CheqdSDK } from './index.js';
 import { Coin, EncodeObject } from '@cosmjs/proto-signing';
 import { Signer } from 'did-jwt';
-import { QueryClient } from '@cosmjs/stargate';
+import { QueryClient, SigningStargateClientOptions } from '@cosmjs/stargate';
 import { DIDDocument, DIDResolutionResult } from 'did-resolver';
 import { DidExtension } from './modules/did.js';
 import { ResourceExtension } from './modules/resource.js';
@@ -37,8 +37,8 @@ export interface TxExtension {
 			memo: string | undefined,
 			signer: Pubkey,
 			signerAddress: string,
-			sequence: number,
-			gasLimit: number
+			gasLimit: number,
+			sequence?: number
 		) => Promise<SimulateResponse>;
 	};
 }
@@ -137,3 +137,9 @@ export const ISignInputs = {
 export enum ServiceType {
 	LinkedDomains = 'LinkedDomains',
 }
+
+export type CheqdSigningStargateClientOptions = SigningStargateClientOptions & {
+	endpoint?: string;
+	simulateSequence?: boolean;
+	gasMultiplier?: number;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@cheqd/sdk",
-    "version": "5.3.0-develop.1",
+    "version": "5.3.0-develop.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@cheqd/sdk",
-            "version": "5.3.0-develop.1",
+            "version": "5.3.0-develop.2",
             "license": "Apache-2.0",
             "workspaces": [
                 "esm",


### PR DESCRIPTION
### Summary

This PR addresses two key issues raised by the community:

1. **Out-of-gas errors due to underestimation of gas fees**
   The default gas multiplier is currently hardcoded to `1.3`, which may not be sufficient in all cases. This fix introduces a configurable gas multiplier, allowing clients to override the default based on their needs.

2. **Blocking of parallel gas estimations due to sequence ID check during simulation**
   The SDK currently performs a sequence ID check during simulation, which prevents parallel transaction estimations. This change makes the sequence check optional to enable better parallelism.

### Changes

* Exposes `signerOptions` at the top level, allowing clients to configure:

  * Gas multiplier
  * Sequence ID check behavior during simulation
