### PR TITLE
fix: externalController logic for required signatures 

### DIFF
--- a/cjs/src/modules/did.ts
+++ b/cjs/src/modules/did.ts
@@ -1222,7 +1222,9 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		if (!querier) throw new Error('querier is required for external controller validation');
 
 		// get external controllers
-		const externalControllers = controllers?.filter((c) => c !== didDocument.id).concat(rotatedControllers);
+		// Only include rotated controllers if they are external (not the current DID itself)
+		const externalRotatedControllers = rotatedControllers.filter((c) => c !== didDocument.id);
+		const externalControllers = controllers?.filter((c) => c !== didDocument.id).concat(externalRotatedControllers);
 
 		// get external controllers' documents
 		const externalControllersDocuments = await Promise.all(

--- a/cjs/tests/modules/did.test.ts
+++ b/cjs/tests/modules/did.test.ts
@@ -1113,7 +1113,7 @@ describe('DIDModule', () => {
 						feePayer,
 						feeUpdate
 					)
-				).rejects.toThrow(/authentication.*not valid|invalid key reference|empty/i);
+				).rejects.toThrow(/authentication.*not valid|invalid key reference|No verification methods provided/i);
 			},
 			defaultAsyncTxTimeout
 		);

--- a/cjs/tests/modules/key-operations.test.ts
+++ b/cjs/tests/modules/key-operations.test.ts
@@ -1,0 +1,720 @@
+import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing-cjs';
+import { DeliverTxResponse } from '@cosmjs/stargate-cjs';
+import { fromString, toString } from 'uint8arrays-cjs';
+import { DIDModule } from '../../src';
+import { createDefaultCheqdRegistry } from '../../src/registry';
+import { CheqdSigningStargateClient } from '../../src/signer';
+import { CheqdNetwork, ISignInputs, MethodSpecificIdAlgo, VerificationMethods } from '../../src/types';
+import {
+	createDidPayload,
+	createDidVerificationMethod,
+	createKeyPairBase64,
+	createVerificationKeys,
+} from '../../src/utils';
+import { localnet, faucet } from '../testutils.test';
+import { CheqdQuerier } from '../../src/querier';
+import { setupDidExtension, DidExtension } from '../../src/modules/did';
+
+const defaultAsyncTxTimeout = 30000;
+
+describe('DID Key Operations (Rotation, Replacement, and Combined)', () => {
+	let didModule: DIDModule;
+	let wallet: DirectSecp256k1HdWallet;
+	let feePayer: string;
+
+	beforeAll(async () => {
+		wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, { prefix: faucet.prefix });
+		const registry = createDefaultCheqdRegistry(DIDModule.registryTypes);
+		const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, {
+			registry,
+		});
+		const querier = (await CheqdQuerier.connectWithExtension(localnet.rpcUrl, setupDidExtension)) as CheqdQuerier &
+			DidExtension;
+
+		didModule = new DIDModule(signer, querier);
+		feePayer = (await wallet.getAccounts())[0].address;
+	}, defaultAsyncTxTimeout);
+
+	describe('Key Rotation Tests', () => {
+		it(
+			'should rotate key material while keeping the same key ID',
+			async () => {
+				// Key rotation: Same verification method ID, different key material
+
+				// Create initial DID with first key
+				const keyPair1 = createKeyPairBase64();
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationMethods1 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys1]
+				);
+				const initialDidPayload = createDidPayload(verificationMethods1, [verificationKeys1]);
+
+				const signInputs1: ISignInputs[] = [
+					{
+						verificationMethodId: initialDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create the DID
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				const createTx = await didModule.createDidDocTx(signInputs1, initialDidPayload, feePayer, feeCreate);
+				expect(createTx.code).toBe(0);
+
+				// Wait for DID to be available
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Create new key material but keep same key ID
+				const keyPair2 = createKeyPairBase64();
+				const verificationKeys2 = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				// Use the SAME DID and key ID as before by creating new verification keys
+				const verificationKeys2WithSameId = {
+					...verificationKeys2,
+					didUrl: verificationKeys1.didUrl,
+					keyId: verificationKeys1.keyId,
+				};
+
+				const verificationMethods2 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys2WithSameId]
+				);
+				const rotatedDidPayload = {
+					...initialDidPayload,
+					verificationMethod: verificationMethods2, // Same ID, different public key material
+				};
+
+				// For key rotation, need signatures from BOTH old and new keys
+				const signInputs2: ISignInputs[] = [
+					{
+						verificationMethodId: rotatedDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair2.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				const combinedSignInputs = [...signInputs1, ...signInputs2]; // Both old and new key signatures
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModule.updateDidDocTx(
+					combinedSignInputs,
+					rotatedDidPayload,
+					feePayer,
+					feeUpdate
+				);
+
+				expect(updateTx.code).toBe(0);
+
+				// Verify the key was rotated (same ID, different material)
+				const queryResult = await didModule.queryDidDoc(initialDidPayload.id);
+				expect(queryResult.didDocument?.verificationMethod![0].id).toBe(verificationKeys1.keyId);
+				expect(queryResult.didDocument?.verificationMethod![0].publicKeyBase58).not.toBe(
+					initialDidPayload.verificationMethod![0].publicKeyBase58
+				);
+			},
+			defaultAsyncTxTimeout
+		);
+
+		it(
+			'should fail key rotation with only old key signature',
+			async () => {
+				// Test that key rotation fails if only old key signs (need both old and new)
+
+				const keyPair1 = createKeyPairBase64();
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationMethods1 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys1]
+				);
+				const initialDidPayload = createDidPayload(verificationMethods1, [verificationKeys1]);
+
+				const signInputs1: ISignInputs[] = [
+					{
+						verificationMethodId: initialDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create the DID
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				await didModule.createDidDocTx(signInputs1, initialDidPayload, feePayer, feeCreate);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Try to rotate with new key material
+				const keyPair2 = createKeyPairBase64();
+				const verificationKeys2 = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationKeys2WithSameId = {
+					...verificationKeys2,
+					didUrl: verificationKeys1.didUrl,
+					keyId: verificationKeys1.keyId,
+				};
+
+				const verificationMethods2 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys2WithSameId]
+				);
+				const rotatedDidPayload = {
+					...initialDidPayload,
+					verificationMethod: verificationMethods2,
+				};
+
+				// Only provide old key signature (missing new key signature)
+				const incompleteSignInputs = [...signInputs1]; // Missing new key signature
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+
+				await expect(
+					didModule.updateDidDocTx(incompleteSignInputs, rotatedDidPayload, feePayer, feeUpdate)
+				).rejects.toThrow(/authentication does not match signatures.*is missing/);
+			},
+			defaultAsyncTxTimeout
+		);
+	});
+
+	describe('Key Replacement Tests', () => {
+		it(
+			'should add new key and change authentication (key replacement pattern)',
+			async () => {
+				// Key replacement pattern: Add new verification method and change authentication to it
+
+				// Create initial DID with first key
+				const keyPair1 = createKeyPairBase64();
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationMethods1 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys1]
+				);
+				const initialDidPayload = createDidPayload(verificationMethods1, [verificationKeys1]);
+
+				const signInputs1: ISignInputs[] = [
+					{
+						verificationMethodId: initialDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create the DID
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				const createTx = await didModule.createDidDocTx(signInputs1, initialDidPayload, feePayer, feeCreate);
+				expect(createTx.code).toBe(0);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Create completely new key with new ID
+				const keyPair2 = createKeyPairBase64();
+				// Create new verification keys with the same DID URL but different key fragment
+				const verificationKeys2WithSameDid = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-2',
+					CheqdNetwork.Testnet,
+					verificationKeys1.methodSpecificId, // Same method specific ID
+					verificationKeys1.didUrl // Same DID URL
+				);
+
+				const verificationMethods2 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys2WithSameDid]
+				);
+				const replacedDidPayload = {
+					...initialDidPayload,
+					verificationMethod: [...initialDidPayload.verificationMethod!, ...verificationMethods2], // Include both for signature validation
+					authentication: [verificationKeys2WithSameDid.keyId], // Update authentication to new key only
+				};
+
+				// For key replacement, need signatures from BOTH old and new keys:
+				// 1. Old key signature to authorize the replacement
+				// 2. New key signature to prove possession
+				const signInputs2: ISignInputs[] = [
+					{
+						verificationMethodId: verificationKeys2WithSameDid.keyId,
+						privateKeyHex: toString(fromString(keyPair2.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				const combinedSignInputs = [...signInputs1, ...signInputs2];
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModule.updateDidDocTx(
+					combinedSignInputs,
+					replacedDidPayload,
+					feePayer,
+					feeUpdate
+				);
+
+				expect(updateTx.code).toBe(0);
+
+				// Verify the replacement worked - should have both keys but only new one in authentication
+				const queryResult = await didModule.queryDidDoc(initialDidPayload.id);
+				expect(queryResult.didDocument?.verificationMethod).toHaveLength(2); // Both keys present
+				expect(queryResult.didDocument?.authentication).toEqual([verificationKeys2WithSameDid.keyId]); // Only new key in auth
+
+				// Verify both keys are present
+				const keyIds = queryResult.didDocument?.verificationMethod!.map((vm) => vm.id);
+				expect(keyIds).toContain(verificationKeys1.keyId); // Old key still present
+				expect(keyIds).toContain(verificationKeys2WithSameDid.keyId); // New key present
+			},
+			defaultAsyncTxTimeout
+		);
+
+		it(
+			'should add additional authentication key (multiple keys scenario)',
+			async () => {
+				// Key addition: Add new key while keeping existing one
+
+				const keyPair1 = createKeyPairBase64();
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationMethods1 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys1]
+				);
+				const initialDidPayload = createDidPayload(verificationMethods1, [verificationKeys1]);
+
+				const signInputs1: ISignInputs[] = [
+					{
+						verificationMethodId: initialDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create the DID
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				await didModule.createDidDocTx(signInputs1, initialDidPayload, feePayer, feeCreate);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Add second key
+				const keyPair2 = createKeyPairBase64();
+				// Create new verification keys with the same DID URL but different key fragment
+				const verificationKeys2WithSameDid = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-2',
+					CheqdNetwork.Testnet,
+					verificationKeys1.methodSpecificId, // Same method specific ID
+					verificationKeys1.didUrl // Same DID URL
+				);
+
+				const verificationMethods2 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys2WithSameDid]
+				);
+				const expandedDidPayload = {
+					...initialDidPayload,
+					verificationMethod: [...initialDidPayload.verificationMethod!, ...verificationMethods2], // Both keys
+					authentication: [verificationKeys1.keyId, verificationKeys2WithSameDid.keyId], // Both in authentication
+				};
+
+				// For adding keys, need signatures from existing key and new key
+				const signInputs2: ISignInputs[] = [
+					{
+						verificationMethodId: verificationKeys2WithSameDid.keyId,
+						privateKeyHex: toString(fromString(keyPair2.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				const combinedSignInputs = [...signInputs1, ...signInputs2];
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModule.updateDidDocTx(
+					combinedSignInputs,
+					expandedDidPayload,
+					feePayer,
+					feeUpdate
+				);
+
+				expect(updateTx.code).toBe(0);
+
+				// Verify both keys are present
+				const queryResult = await didModule.queryDidDoc(initialDidPayload.id);
+				expect(queryResult.didDocument?.verificationMethod).toHaveLength(2);
+				expect(queryResult.didDocument?.authentication).toEqual([
+					verificationKeys1.keyId,
+					verificationKeys2WithSameDid.keyId,
+				]);
+			},
+			defaultAsyncTxTimeout
+		);
+	});
+
+	describe('Combined Key Operations', () => {
+		it(
+			'should handle key rotation and replacement simultaneously',
+			async () => {
+				// Complex scenario: Rotate one key and replace another in the same transaction
+
+				// Create initial DID with two keys
+				const keyPair1 = createKeyPairBase64();
+				const keyPair2 = createKeyPairBase64();
+
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				// Create new verification keys with the same DID URL but different key fragment
+				const verificationKeys2WithSameDid = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-2',
+					CheqdNetwork.Testnet,
+					verificationKeys1.methodSpecificId, // Same method specific ID
+					verificationKeys1.didUrl // Same DID URL
+				);
+
+				const verificationMethods = [
+					...createDidVerificationMethod([VerificationMethods.Ed255192018], [verificationKeys1]),
+					...createDidVerificationMethod([VerificationMethods.Ed255192018], [verificationKeys2WithSameDid]),
+				];
+
+				const initialDidPayload = {
+					...createDidPayload(verificationMethods, [verificationKeys1, verificationKeys2WithSameDid]),
+					authentication: [verificationKeys1.keyId, verificationKeys2WithSameDid.keyId],
+				};
+
+				const initialSignInputs: ISignInputs[] = [
+					{
+						verificationMethodId: verificationKeys1.keyId,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+					{
+						verificationMethodId: verificationKeys2WithSameDid.keyId,
+						privateKeyHex: toString(fromString(keyPair2.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create the DID
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				await didModule.createDidDocTx(initialSignInputs, initialDidPayload, feePayer, feeCreate);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Now perform combined operations:
+				// 1. Rotate key-1 (same ID, new material)
+				// 2. Replace key-2 with key-3 (different ID, different material)
+
+				const keyPair1New = createKeyPairBase64(); // New material for key-1 rotation
+				const keyPair3 = createKeyPairBase64(); // Completely new key-3
+
+				const rotatedVerificationKeys1 = createVerificationKeys(
+					keyPair1New.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const rotatedVerificationKeys1WithSameId = {
+					...rotatedVerificationKeys1,
+					didUrl: verificationKeys1.didUrl,
+					keyId: verificationKeys1.keyId, // Same ID for rotation
+				};
+
+				// Create new verification keys with the same DID URL but different key fragment
+				const replacementVerificationKeys3WithSameDid = createVerificationKeys(
+					keyPair3.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-3',
+					CheqdNetwork.Testnet,
+					verificationKeys1.methodSpecificId, // Same method specific ID
+					verificationKeys1.didUrl // Same DID URL
+				);
+
+				const newVerificationMethods = [
+					...createDidVerificationMethod(
+						[VerificationMethods.Ed255192018],
+						[rotatedVerificationKeys1WithSameId]
+					), // Rotated key-1
+					...createDidVerificationMethod(
+						[VerificationMethods.Ed255192018],
+						[replacementVerificationKeys3WithSameDid]
+					), // New key-3
+				];
+
+				const combinedDidPayload = {
+					...initialDidPayload,
+					verificationMethod: newVerificationMethods,
+					// new authentication and assertionMethod: key-1 (rotated) + key-3 (new)
+					// must update assertionMethod as well otherwise it will fail validation
+					authentication: [
+						rotatedVerificationKeys1WithSameId.keyId,
+						replacementVerificationKeys3WithSameDid.keyId,
+					],
+					assertionMethod: [
+						rotatedVerificationKeys1WithSameId.keyId,
+						replacementVerificationKeys3WithSameDid.keyId,
+					],
+				};
+
+				// Need signatures from existing keys that can authorize the changes:
+				// - Old key-1 (for rotation authorization)
+				// - New key-1 (for rotation proof of possession) - same ID as old key-1
+				// Note: key-2 signature not needed since it doesn't exist in new DIDDoc
+				const combinedSignInputs: ISignInputs[] = [
+					// Old key-1 (authorization for rotation)
+					{
+						verificationMethodId: verificationKeys1.keyId,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+					// New key-1 material (proof of possession) - same ID, different material
+					{
+						verificationMethodId: rotatedVerificationKeys1WithSameId.keyId, // Same ID as old key-1
+						privateKeyHex: toString(fromString(keyPair1New.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModule.updateDidDocTx(
+					combinedSignInputs,
+					combinedDidPayload,
+					feePayer,
+					feeUpdate
+				);
+
+				expect(updateTx.code).toBe(0);
+
+				// Verify the complex operation worked
+				const queryResult = await didModule.queryDidDoc(initialDidPayload.id);
+				expect(queryResult.didDocument).toBeDefined();
+				expect(queryResult.didDocument?.verificationMethod).toHaveLength(2);
+
+				// Check that key-1 was rotated (same ID, different material)
+				const rotatedKey = queryResult.didDocument?.verificationMethod!.find(
+					(vm) => vm.id === verificationKeys1.keyId
+				);
+				expect(rotatedKey).toBeDefined();
+				expect(rotatedKey!.publicKeyBase58).not.toBe(initialDidPayload.verificationMethod![0].publicKeyBase58);
+
+				// Check that key-2 was replaced with key-3
+				const replacedKey = queryResult.didDocument?.verificationMethod!.find(
+					(vm) => vm.id === replacementVerificationKeys3WithSameDid.keyId
+				);
+				expect(replacedKey).toBeDefined();
+				expect(
+					queryResult.didDocument?.verificationMethod!.find(
+						(vm) => vm.id === verificationKeys2WithSameDid.keyId
+					)
+				).toBeUndefined();
+
+				// Check authentication was updated correctly
+				expect(queryResult.didDocument?.authentication).toEqual([
+					rotatedVerificationKeys1WithSameId.keyId,
+					replacementVerificationKeys3WithSameDid.keyId,
+				]);
+			},
+			defaultAsyncTxTimeout
+		);
+	});
+
+	describe('Edge Cases and Error Scenarios', () => {
+		it(
+			'should fail when attempting key rotation with external controllers',
+			async () => {
+				// Test that key rotation fails when DID has external controllers
+				// The blockchain doesn't support simultaneous key changes and controller authorization
+
+				// Create controller DID first
+				const controllerKeyPair = createKeyPairBase64();
+				const controllerVerificationKeys = createVerificationKeys(
+					controllerKeyPair.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1' // Use standard key fragment format
+				);
+				const controllerVerificationMethods = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[controllerVerificationKeys]
+				);
+				const controllerDidPayload = createDidPayload(controllerVerificationMethods, [
+					controllerVerificationKeys,
+				]);
+
+				const controllerSignInputs: ISignInputs[] = [
+					{
+						verificationMethodId: controllerDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(controllerKeyPair.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create controller DID
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				await didModule.createDidDocTx(controllerSignInputs, controllerDidPayload, feePayer, feeCreate);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Create target DID with external controller
+				const targetKeyPair = createKeyPairBase64();
+				const targetVerificationKeys = createVerificationKeys(
+					targetKeyPair.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1' // Use standard key fragment format
+				);
+				const targetVerificationMethods = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[targetVerificationKeys]
+				);
+				const targetDidPayload = {
+					...createDidPayload(targetVerificationMethods, [targetVerificationKeys]),
+					controller: [controllerDidPayload.id], // External controller
+					verificationMethod: [...targetVerificationMethods, ...controllerVerificationMethods], // Include verification methods
+				};
+
+				const targetSignInputs: ISignInputs[] = [
+					{
+						verificationMethodId: targetDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(targetKeyPair.privateKey, 'base64'), 'hex'),
+					},
+					{
+						verificationMethodId: controllerVerificationKeys.keyId, // Controller must also sign
+						privateKeyHex: toString(fromString(controllerKeyPair.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create target DID with external controller
+				const createSignInputs = [...targetSignInputs];
+				try {
+					const didTx: DeliverTxResponse = await didModule.createDidDocTx(
+						createSignInputs,
+						targetDidPayload,
+						feePayer,
+						feeCreate
+					);
+				} catch (error: Error | any) {
+					// Expect failure due to external controller presence
+					expect(error.code).toBe(1205); // cheqd error code
+					expect(error.codespace).toBe('cheqd');
+					expect(error.log).toContain('payload: (verification_method: (1: (id: must have prefix:');
+				}
+			},
+			defaultAsyncTxTimeout
+		);
+		it(
+			'should fail when trying to rotate non-existent key',
+			async () => {
+				const keyPair1 = createKeyPairBase64();
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationMethods1 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys1]
+				);
+				const initialDidPayload = createDidPayload(verificationMethods1, [verificationKeys1]);
+
+				const signInputs1: ISignInputs[] = [
+					{
+						verificationMethodId: initialDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				await didModule.createDidDocTx(signInputs1, initialDidPayload, feePayer, feeCreate);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Try to rotate a key ID that doesn't exist
+				const keyPair2 = createKeyPairBase64();
+				const verificationKeys2 = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-2' // Different key fragment - simulates non-existent key
+				);
+				const verificationKeys2WithSameDid = {
+					...verificationKeys2,
+					didUrl: verificationKeys1.didUrl,
+				};
+
+				const verificationMethods2 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys2WithSameDid]
+				);
+				const invalidDidPayload = {
+					...initialDidPayload,
+					verificationMethod: verificationMethods2, // Non-existent key ID
+				};
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+
+				await expect(
+					didModule.updateDidDocTx(signInputs1, invalidDidPayload, feePayer, feeUpdate)
+				).rejects.toThrow();
+			},
+			defaultAsyncTxTimeout
+		);
+
+		it(
+			'should fail key operations with insufficient signatures',
+			async () => {
+				const keyPair1 = createKeyPairBase64();
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationMethods1 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys1]
+				);
+				const initialDidPayload = createDidPayload(verificationMethods1, [verificationKeys1]);
+
+				const signInputs1: ISignInputs[] = [
+					{
+						verificationMethodId: initialDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				await didModule.createDidDocTx(signInputs1, initialDidPayload, feePayer, feeCreate);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Try rotation with missing new key signature
+				const keyPair2 = createKeyPairBase64();
+				const verificationKeys2 = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationKeys2WithSameId = {
+					...verificationKeys2,
+					didUrl: verificationKeys1.didUrl,
+					keyId: verificationKeys1.keyId,
+				};
+
+				const verificationMethods2 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys2WithSameId]
+				);
+				const rotatedDidPayload = {
+					...initialDidPayload,
+					verificationMethod: verificationMethods2,
+				};
+
+				// Only provide old key signature (missing new key)
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+
+				await expect(
+					didModule.updateDidDocTx(signInputs1, rotatedDidPayload, feePayer, feeUpdate)
+				).rejects.toThrow(/authentication does not match signatures.*is missing/);
+			},
+			defaultAsyncTxTimeout
+		);
+	});
+});

--- a/esm/src/modules/did.ts
+++ b/esm/src/modules/did.ts
@@ -1207,7 +1207,9 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		if (!querier) throw new Error('querier is required for external controller validation');
 
 		// get external controllers
-		const externalControllers = controllers?.filter((c) => c !== didDocument.id).concat(rotatedControllers);
+		// Only include rotated controllers if they are external (not the current DID itself)
+		const externalRotatedControllers = rotatedControllers.filter((c) => c !== didDocument.id);
+		const externalControllers = controllers?.filter((c) => c !== didDocument.id).concat(externalRotatedControllers);
 
 		// get external controllers' documents
 		const externalControllersDocuments = await Promise.all(

--- a/esm/tests/modules/did.test.ts
+++ b/esm/tests/modules/did.test.ts
@@ -62,6 +62,21 @@ describe('DIDModule', () => {
 				);
 				const didPayload = createDidPayload(verificationMethods, [verificationKeys]);
 
+				didPayload.service = [
+					{
+						id: `${didPayload.id}#service-1`,
+						serviceEndpoint: 'endpoint1',
+						type: 'didcomm',
+						accept: ['application/didcomm-plain+json'],
+						priority: 0,
+					},
+					{
+						id: `${didPayload.id}#service-2`,
+						serviceEndpoint: 'endpoint2',
+						type: 'website',
+					},
+				];
+
 				const signInputs: ISignInputs[] = [
 					{
 						verificationMethodId: didPayload.verificationMethod![0].id,
@@ -823,7 +838,353 @@ describe('DIDModule', () => {
 			defaultAsyncTxTimeout
 		);
 	});
+	// Tests for controller changes, including self-controller to external controller transitions
+	// and switching between different external controllers.
+	describe('Controller Switch Scenarios', () => {
+		let didModuleA: DIDModule;
+		let didModuleB: DIDModule;
+		let didModuleC: DIDModule;
+		let didPayloadA: DIDDocument;
+		let didPayloadB: DIDDocument;
+		let didPayloadC: DIDDocument;
+		let keyPairA: any;
+		let keyPairB: any;
+		let keyPairC: any;
+		let signInputsA: ISignInputs[];
+		let signInputsB: ISignInputs[];
+		let signInputsC: ISignInputs[];
+		let wallet: DirectSecp256k1HdWallet;
+		let feePayer: string;
 
+		beforeAll(async () => {
+			// Setup common test infrastructure
+			wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, { prefix: faucet.prefix });
+			const registry = createDefaultCheqdRegistry(DIDModule.registryTypes);
+			const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, {
+				registry,
+			});
+			const querier = (await CheqdQuerier.connectWithExtension(
+				localnet.rpcUrl,
+				setupDidExtension
+			)) as CheqdQuerier & DidExtension;
+
+			didModuleA = new DIDModule(signer, querier);
+			didModuleB = new DIDModule(signer, querier);
+			didModuleC = new DIDModule(signer, querier);
+			feePayer = (await wallet.getAccounts())[0].address;
+
+			// Create key pairs for all DIDs
+			keyPairA = createKeyPairBase64();
+			keyPairB = createKeyPairBase64();
+			keyPairC = createKeyPairBase64();
+
+			// Create DID A (will be the target DID for controller changes)
+			const verificationKeysA = createVerificationKeys(keyPairA.publicKey, MethodSpecificIdAlgo.Uuid, 'key-1');
+			const verificationMethodsA = createDidVerificationMethod(
+				[VerificationMethods.Ed255192018],
+				[verificationKeysA]
+			);
+			didPayloadA = createDidPayload(verificationMethodsA, [verificationKeysA]);
+			signInputsA = [
+				{
+					verificationMethodId: didPayloadA.verificationMethod![0].id,
+					privateKeyHex: toString(fromString(keyPairA.privateKey, 'base64'), 'hex'),
+				},
+			];
+
+			// Create DID B (will be used as external controller)
+			const verificationKeysB = createVerificationKeys(keyPairB.publicKey, MethodSpecificIdAlgo.Uuid, 'key-1');
+			const verificationMethodsB = createDidVerificationMethod(
+				[VerificationMethods.Ed255192018],
+				[verificationKeysB]
+			);
+			didPayloadB = createDidPayload(verificationMethodsB, [verificationKeysB]);
+			signInputsB = [
+				{
+					verificationMethodId: didPayloadB.verificationMethod![0].id,
+					privateKeyHex: toString(fromString(keyPairB.privateKey, 'base64'), 'hex'),
+				},
+			];
+
+			// Create DID C (will be used as another external controller)
+			const verificationKeysC = createVerificationKeys(keyPairC.publicKey, MethodSpecificIdAlgo.Uuid, 'key-1');
+			const verificationMethodsC = createDidVerificationMethod(
+				[VerificationMethods.Ed255192018],
+				[verificationKeysC]
+			);
+			didPayloadC = createDidPayload(verificationMethodsC, [verificationKeysC]);
+			signInputsC = [
+				{
+					verificationMethodId: didPayloadC.verificationMethod![0].id,
+					privateKeyHex: toString(fromString(keyPairC.privateKey, 'base64'), 'hex'),
+				},
+			];
+
+			// Create all DIDs on blockchain
+			const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+
+			await didModuleA.createDidDocTx(signInputsA, didPayloadA, feePayer, feeCreate);
+			await didModuleB.createDidDocTx(signInputsB, didPayloadB, feePayer, feeCreate);
+			await didModuleC.createDidDocTx(signInputsC, didPayloadC, feePayer, feeCreate);
+
+			// Add short delay to ensure DIDs are available
+			await new Promise((resolve) => setTimeout(resolve, 2000));
+		}, defaultAsyncTxTimeout);
+
+		it(
+			'should add external controller to existing self-controlled DID',
+			async () => {
+				// Test case: Add external controller B to DID A
+				// Before: DID A controller = [DID A]
+				// After: DID A controller = [DID A, DID B]
+
+				const updatedDidPayloadA = {
+					...didPayloadA,
+					controller: [didPayloadA.id, didPayloadB.id], // Add external controller
+				};
+
+				// Need signatures from both DID A and DID B
+				const combinedSignInputs = [...signInputsA, ...signInputsB];
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModuleA.updateDidDocTx(
+					combinedSignInputs,
+					updatedDidPayloadA,
+					feePayer,
+					feeUpdate
+				);
+
+				expect(updateTx.code).toBe(0);
+
+				// Verify the DID was updated correctly
+				const queryResult = await didModuleA.queryDidDoc(didPayloadA.id);
+				expect(queryResult.didDocument?.controller).toEqual([didPayloadA.id, didPayloadB.id]);
+			},
+			defaultAsyncTxTimeout
+		);
+
+		it(
+			'should remove self-controller leaving only external controller',
+			async () => {
+				// Test case: Remove DID A as controller, leaving only DID B
+				// Before: DID A controller = [DID A, DID B]
+				// After: DID A controller = [DID B]
+
+				const updatedDidPayloadA = {
+					...didPayloadA,
+					controller: [didPayloadB.id], // Remove self, keep only external controller
+				};
+
+				// Need signatures from both current controllers (A and B)
+				const combinedSignInputs = [...signInputsA, ...signInputsB];
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModuleA.updateDidDocTx(
+					combinedSignInputs,
+					updatedDidPayloadA,
+					feePayer,
+					feeUpdate
+				);
+
+				expect(updateTx.code).toBe(0);
+
+				// Verify the DID was updated correctly - should only have external controller now
+				const queryResult = await didModuleA.queryDidDoc(didPayloadA.id);
+				expect(queryResult.didDocument?.controller).toEqual([didPayloadB.id]);
+			},
+			defaultAsyncTxTimeout
+		);
+
+		it(
+			'should switch from one external controller to another',
+			async () => {
+				// Test case: Switch from controller B to controller C
+				// Before: DID A controller = [DID B]
+				// After: DID A controller = [DID C]
+
+				const updatedDidPayloadA = {
+					...didPayloadA,
+					controller: [didPayloadC.id], // Switch to controller C
+				};
+
+				// Need signatures from current controller (B) and new controller (C)
+				const combinedSignInputs = [...signInputsB, ...signInputsC];
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModuleA.updateDidDocTx(
+					combinedSignInputs,
+					updatedDidPayloadA,
+					feePayer,
+					feeUpdate
+				);
+
+				expect(updateTx.code).toBe(0);
+
+				// Verify the controller switched correctly
+				const queryResult = await didModuleA.queryDidDoc(didPayloadA.id);
+				expect(queryResult.didDocument?.controller).toEqual([didPayloadC.id]);
+			},
+			defaultAsyncTxTimeout
+		);
+
+		it(
+			'should add multiple external controllers simultaneously',
+			async () => {
+				// Test case: Add multiple controllers at once
+				// Before: DID A controller = [DID C]
+				// After: DID A controller = [DID B, DID C]
+
+				const updatedDidPayloadA = {
+					...didPayloadA,
+					controller: [didPayloadB.id, didPayloadC.id], // Multiple external controllers
+				};
+
+				// Need signatures from current controller (C) and new controller (B)
+				const combinedSignInputs = [...signInputsB, ...signInputsC];
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModuleA.updateDidDocTx(
+					combinedSignInputs,
+					updatedDidPayloadA,
+					feePayer,
+					feeUpdate
+				);
+
+				expect(updateTx.code).toBe(0);
+
+				// Verify multiple controllers were set
+				const queryResult = await didModuleA.queryDidDoc(didPayloadA.id);
+				expect(queryResult.didDocument?.controller).toEqual([didPayloadB.id, didPayloadC.id]);
+			},
+			defaultAsyncTxTimeout
+		);
+
+		it(
+			'should restore self-control from external controllers',
+			async () => {
+				// Test case: Return to self-controlled DID
+				// Before: DID A controller = [DID B, DID C]
+				// After: DID A controller = [DID A]
+
+				const updatedDidPayloadA = {
+					...didPayloadA,
+					controller: [didPayloadA.id], // Back to self-controlled
+				};
+
+				// Need signatures from current controllers (B and C) and the DID itself (A)
+				const combinedSignInputs = [...signInputsA, ...signInputsB, ...signInputsC];
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModuleA.updateDidDocTx(
+					combinedSignInputs,
+					updatedDidPayloadA,
+					feePayer,
+					feeUpdate
+				);
+
+				expect(updateTx.code).toBe(0);
+
+				// Verify back to self-controlled
+				const queryResult = await didModuleA.queryDidDoc(didPayloadA.id);
+				expect(queryResult.didDocument?.controller).toEqual([didPayloadA.id]);
+			},
+			defaultAsyncTxTimeout
+		);
+
+		it(
+			'should fail when missing required controller signature during switch',
+			async () => {
+				// Test case: Try to add controller without proper signatures
+				// This should fail validation
+
+				const updatedDidPayloadA = {
+					...didPayloadA,
+					controller: [didPayloadA.id, didPayloadB.id], // Add external controller
+				};
+
+				// Only provide signature from DID A, missing signature from DID B
+				const incompleteSignInputs = [...signInputsA]; // Missing signInputsB
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+
+				// This should fail due to missing signature
+				const updateTx = await didModuleA.updateDidDocTx(
+					incompleteSignInputs,
+					updatedDidPayloadA,
+					feePayer,
+					feeUpdate
+				);
+
+				// Should return a failed transaction with error code
+				expect(updateTx.code).not.toBe(0);
+				expect(updateTx.rawLog).toMatch(/signature is required but not found/);
+			},
+			defaultAsyncTxTimeout
+		);
+
+		it(
+			'should handle DID with default assertionMethod during controller rotation',
+			async () => {
+				// Test case: Ensure the fix works with assertionMethod populated
+				// This specifically tests the scenario that was failing before the fix
+
+				const updatedDidPayloadA = {
+					...didPayloadA,
+					controller: [didPayloadB.id], // Switch to external controller only
+					// Ensure assertionMethod is populated (this triggers the original bug)
+					assertionMethod: didPayloadA.verificationMethod!.map((vm) => vm.id),
+				};
+
+				// Need signatures from both current controller (A) and new controller (B)
+				const combinedSignInputs = [...signInputsA, ...signInputsB];
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModuleA.updateDidDocTx(
+					combinedSignInputs,
+					updatedDidPayloadA,
+					feePayer,
+					feeUpdate
+				);
+
+				// This should succeed with our fix (previously would fail)
+				expect(updateTx.code).toBe(0);
+
+				// Verify the update worked correctly
+				const queryResult = await didModuleA.queryDidDoc(didPayloadA.id);
+				expect(queryResult.didDocument?.controller).toEqual([didPayloadB.id]);
+				expect(queryResult.didDocument?.assertionMethod).toEqual(
+					didPayloadA.verificationMethod!.map((vm) => vm.id)
+				);
+			},
+			defaultAsyncTxTimeout
+		);
+
+		it(
+			'should fail when trying to update DID with empty verificationMethod list',
+			async () => {
+				// Test case: Try to send updated DID Document with empty verificationMethod list
+				const updatedDidPayloadA = {
+					...didPayloadA,
+					verificationMethod: [], // Empty verification methods - should be invalid
+					authentication: [], // Also clear authentication to avoid client-side validation error
+					assertionMethod: [], // Clear assertion method as well
+				};
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+
+				// This should throw an error during client-side validation
+				await expect(
+					didModuleA.updateDidDocTx(
+						signInputsB, // Current controller B signature
+						updatedDidPayloadA,
+						feePayer,
+						feeUpdate
+					)
+				).rejects.toThrow(/authentication.*not valid|invalid key reference|empty/i);
+			},
+			defaultAsyncTxTimeout
+		);
+	});
 	describe('deactivateDidDocTx', () => {
 		it(
 			'should deactivate a DID - case: Ed25519VerificationKey2020',

--- a/esm/tests/modules/did.test.ts
+++ b/esm/tests/modules/did.test.ts
@@ -1180,7 +1180,7 @@ describe('DIDModule', () => {
 						feePayer,
 						feeUpdate
 					)
-				).rejects.toThrow(/authentication.*not valid|invalid key reference|empty/i);
+				).rejects.toThrow(/authentication.*not valid|invalid key reference|No verification methods provided/i);
 			},
 			defaultAsyncTxTimeout
 		);

--- a/esm/tests/modules/key-operations.test.ts
+++ b/esm/tests/modules/key-operations.test.ts
@@ -1,0 +1,720 @@
+import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
+import { fromString, toString } from 'uint8arrays';
+import { DIDModule } from '../../src';
+import { createDefaultCheqdRegistry } from '../../src/registry';
+import { CheqdSigningStargateClient } from '../../src/signer';
+import { CheqdNetwork, ISignInputs, MethodSpecificIdAlgo, VerificationMethods } from '../../src/types';
+import {
+	createDidPayload,
+	createDidVerificationMethod,
+	createKeyPairBase64,
+	createVerificationKeys,
+} from '../../src/utils';
+import { localnet, faucet } from '../testutils.test';
+import { CheqdQuerier } from '../../src/querier';
+import { setupDidExtension, DidExtension } from '../../src/modules/did';
+import { DeliverTxResponse } from '@cosmjs/stargate';
+
+const defaultAsyncTxTimeout = 30000;
+
+describe('DID Key Operations (Rotation, Replacement, and Combined)', () => {
+	let didModule: DIDModule;
+	let wallet: DirectSecp256k1HdWallet;
+	let feePayer: string;
+
+	beforeAll(async () => {
+		wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic, { prefix: faucet.prefix });
+		const registry = createDefaultCheqdRegistry(DIDModule.registryTypes);
+		const signer = await CheqdSigningStargateClient.connectWithSigner(localnet.rpcUrl, wallet, {
+			registry,
+		});
+		const querier = (await CheqdQuerier.connectWithExtension(localnet.rpcUrl, setupDidExtension)) as CheqdQuerier &
+			DidExtension;
+
+		didModule = new DIDModule(signer, querier);
+		feePayer = (await wallet.getAccounts())[0].address;
+	}, defaultAsyncTxTimeout);
+
+	describe('Key Rotation Tests', () => {
+		it(
+			'should rotate key material while keeping the same key ID',
+			async () => {
+				// Key rotation: Same verification method ID, different key material
+
+				// Create initial DID with first key
+				const keyPair1 = createKeyPairBase64();
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationMethods1 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys1]
+				);
+				const initialDidPayload = createDidPayload(verificationMethods1, [verificationKeys1]);
+
+				const signInputs1: ISignInputs[] = [
+					{
+						verificationMethodId: initialDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create the DID
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				const createTx = await didModule.createDidDocTx(signInputs1, initialDidPayload, feePayer, feeCreate);
+				expect(createTx.code).toBe(0);
+
+				// Wait for DID to be available
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Create new key material but keep same key ID
+				const keyPair2 = createKeyPairBase64();
+				const verificationKeys2 = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				// Use the SAME DID and key ID as before by creating new verification keys
+				const verificationKeys2WithSameId = {
+					...verificationKeys2,
+					didUrl: verificationKeys1.didUrl,
+					keyId: verificationKeys1.keyId,
+				};
+
+				const verificationMethods2 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys2WithSameId]
+				);
+				const rotatedDidPayload = {
+					...initialDidPayload,
+					verificationMethod: verificationMethods2, // Same ID, different public key material
+				};
+
+				// For key rotation, need signatures from BOTH old and new keys
+				const signInputs2: ISignInputs[] = [
+					{
+						verificationMethodId: rotatedDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair2.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				const combinedSignInputs = [...signInputs1, ...signInputs2]; // Both old and new key signatures
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModule.updateDidDocTx(
+					combinedSignInputs,
+					rotatedDidPayload,
+					feePayer,
+					feeUpdate
+				);
+
+				expect(updateTx.code).toBe(0);
+
+				// Verify the key was rotated (same ID, different material)
+				const queryResult = await didModule.queryDidDoc(initialDidPayload.id);
+				expect(queryResult.didDocument?.verificationMethod![0].id).toBe(verificationKeys1.keyId);
+				expect(queryResult.didDocument?.verificationMethod![0].publicKeyBase58).not.toBe(
+					initialDidPayload.verificationMethod![0].publicKeyBase58
+				);
+			},
+			defaultAsyncTxTimeout
+		);
+
+		it(
+			'should fail key rotation with only old key signature',
+			async () => {
+				// Test that key rotation fails if only old key signs (need both old and new)
+
+				const keyPair1 = createKeyPairBase64();
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationMethods1 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys1]
+				);
+				const initialDidPayload = createDidPayload(verificationMethods1, [verificationKeys1]);
+
+				const signInputs1: ISignInputs[] = [
+					{
+						verificationMethodId: initialDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create the DID
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				await didModule.createDidDocTx(signInputs1, initialDidPayload, feePayer, feeCreate);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Try to rotate with new key material
+				const keyPair2 = createKeyPairBase64();
+				const verificationKeys2 = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationKeys2WithSameId = {
+					...verificationKeys2,
+					didUrl: verificationKeys1.didUrl,
+					keyId: verificationKeys1.keyId,
+				};
+
+				const verificationMethods2 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys2WithSameId]
+				);
+				const rotatedDidPayload = {
+					...initialDidPayload,
+					verificationMethod: verificationMethods2,
+				};
+
+				// Only provide old key signature (missing new key signature)
+				const incompleteSignInputs = [...signInputs1]; // Missing new key signature
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+
+				await expect(
+					didModule.updateDidDocTx(incompleteSignInputs, rotatedDidPayload, feePayer, feeUpdate)
+				).rejects.toThrow(/authentication does not match signatures.*is missing/);
+			},
+			defaultAsyncTxTimeout
+		);
+	});
+
+	describe('Key Replacement Tests', () => {
+		it(
+			'should add new key and change authentication (key replacement pattern)',
+			async () => {
+				// Key replacement pattern: Add new verification method and change authentication to it
+
+				// Create initial DID with first key
+				const keyPair1 = createKeyPairBase64();
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationMethods1 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys1]
+				);
+				const initialDidPayload = createDidPayload(verificationMethods1, [verificationKeys1]);
+
+				const signInputs1: ISignInputs[] = [
+					{
+						verificationMethodId: initialDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create the DID
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				const createTx = await didModule.createDidDocTx(signInputs1, initialDidPayload, feePayer, feeCreate);
+				expect(createTx.code).toBe(0);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Create completely new key with new ID
+				const keyPair2 = createKeyPairBase64();
+				// Create new verification keys with the same DID URL but different key fragment
+				const verificationKeys2WithSameDid = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-2',
+					CheqdNetwork.Testnet,
+					verificationKeys1.methodSpecificId, // Same method specific ID
+					verificationKeys1.didUrl // Same DID URL
+				);
+
+				const verificationMethods2 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys2WithSameDid]
+				);
+				const replacedDidPayload = {
+					...initialDidPayload,
+					verificationMethod: [...initialDidPayload.verificationMethod!, ...verificationMethods2], // Include both for signature validation
+					authentication: [verificationKeys2WithSameDid.keyId], // Update authentication to new key only
+				};
+
+				// For key replacement, need signatures from BOTH old and new keys:
+				// 1. Old key signature to authorize the replacement
+				// 2. New key signature to prove possession
+				const signInputs2: ISignInputs[] = [
+					{
+						verificationMethodId: verificationKeys2WithSameDid.keyId,
+						privateKeyHex: toString(fromString(keyPair2.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				const combinedSignInputs = [...signInputs1, ...signInputs2];
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModule.updateDidDocTx(
+					combinedSignInputs,
+					replacedDidPayload,
+					feePayer,
+					feeUpdate
+				);
+
+				expect(updateTx.code).toBe(0);
+
+				// Verify the replacement worked - should have both keys but only new one in authentication
+				const queryResult = await didModule.queryDidDoc(initialDidPayload.id);
+				expect(queryResult.didDocument?.verificationMethod).toHaveLength(2); // Both keys present
+				expect(queryResult.didDocument?.authentication).toEqual([verificationKeys2WithSameDid.keyId]); // Only new key in auth
+
+				// Verify both keys are present
+				const keyIds = queryResult.didDocument?.verificationMethod!.map((vm) => vm.id);
+				expect(keyIds).toContain(verificationKeys1.keyId); // Old key still present
+				expect(keyIds).toContain(verificationKeys2WithSameDid.keyId); // New key present
+			},
+			defaultAsyncTxTimeout
+		);
+
+		it(
+			'should add additional authentication key (multiple keys scenario)',
+			async () => {
+				// Key addition: Add new key while keeping existing one
+
+				const keyPair1 = createKeyPairBase64();
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationMethods1 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys1]
+				);
+				const initialDidPayload = createDidPayload(verificationMethods1, [verificationKeys1]);
+
+				const signInputs1: ISignInputs[] = [
+					{
+						verificationMethodId: initialDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create the DID
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				await didModule.createDidDocTx(signInputs1, initialDidPayload, feePayer, feeCreate);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Add second key
+				const keyPair2 = createKeyPairBase64();
+				// Create new verification keys with the same DID URL but different key fragment
+				const verificationKeys2WithSameDid = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-2',
+					CheqdNetwork.Testnet,
+					verificationKeys1.methodSpecificId, // Same method specific ID
+					verificationKeys1.didUrl // Same DID URL
+				);
+
+				const verificationMethods2 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys2WithSameDid]
+				);
+				const expandedDidPayload = {
+					...initialDidPayload,
+					verificationMethod: [...initialDidPayload.verificationMethod!, ...verificationMethods2], // Both keys
+					authentication: [verificationKeys1.keyId, verificationKeys2WithSameDid.keyId], // Both in authentication
+				};
+
+				// For adding keys, need signatures from existing key and new key
+				const signInputs2: ISignInputs[] = [
+					{
+						verificationMethodId: verificationKeys2WithSameDid.keyId,
+						privateKeyHex: toString(fromString(keyPair2.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				const combinedSignInputs = [...signInputs1, ...signInputs2];
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModule.updateDidDocTx(
+					combinedSignInputs,
+					expandedDidPayload,
+					feePayer,
+					feeUpdate
+				);
+
+				expect(updateTx.code).toBe(0);
+
+				// Verify both keys are present
+				const queryResult = await didModule.queryDidDoc(initialDidPayload.id);
+				expect(queryResult.didDocument?.verificationMethod).toHaveLength(2);
+				expect(queryResult.didDocument?.authentication).toEqual([
+					verificationKeys1.keyId,
+					verificationKeys2WithSameDid.keyId,
+				]);
+			},
+			defaultAsyncTxTimeout
+		);
+	});
+
+	describe('Combined Key Operations', () => {
+		it(
+			'should handle key rotation and replacement simultaneously',
+			async () => {
+				// Complex scenario: Rotate one key and replace another in the same transaction
+
+				// Create initial DID with two keys
+				const keyPair1 = createKeyPairBase64();
+				const keyPair2 = createKeyPairBase64();
+
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				// Create new verification keys with the same DID URL but different key fragment
+				const verificationKeys2WithSameDid = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-2',
+					CheqdNetwork.Testnet,
+					verificationKeys1.methodSpecificId, // Same method specific ID
+					verificationKeys1.didUrl // Same DID URL
+				);
+
+				const verificationMethods = [
+					...createDidVerificationMethod([VerificationMethods.Ed255192018], [verificationKeys1]),
+					...createDidVerificationMethod([VerificationMethods.Ed255192018], [verificationKeys2WithSameDid]),
+				];
+
+				const initialDidPayload = {
+					...createDidPayload(verificationMethods, [verificationKeys1, verificationKeys2WithSameDid]),
+					authentication: [verificationKeys1.keyId, verificationKeys2WithSameDid.keyId],
+				};
+
+				const initialSignInputs: ISignInputs[] = [
+					{
+						verificationMethodId: verificationKeys1.keyId,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+					{
+						verificationMethodId: verificationKeys2WithSameDid.keyId,
+						privateKeyHex: toString(fromString(keyPair2.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create the DID
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				await didModule.createDidDocTx(initialSignInputs, initialDidPayload, feePayer, feeCreate);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Now perform combined operations:
+				// 1. Rotate key-1 (same ID, new material)
+				// 2. Replace key-2 with key-3 (different ID, different material)
+
+				const keyPair1New = createKeyPairBase64(); // New material for key-1 rotation
+				const keyPair3 = createKeyPairBase64(); // Completely new key-3
+
+				const rotatedVerificationKeys1 = createVerificationKeys(
+					keyPair1New.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const rotatedVerificationKeys1WithSameId = {
+					...rotatedVerificationKeys1,
+					didUrl: verificationKeys1.didUrl,
+					keyId: verificationKeys1.keyId, // Same ID for rotation
+				};
+
+				// Create new verification keys with the same DID URL but different key fragment
+				const replacementVerificationKeys3WithSameDid = createVerificationKeys(
+					keyPair3.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-3',
+					CheqdNetwork.Testnet,
+					verificationKeys1.methodSpecificId, // Same method specific ID
+					verificationKeys1.didUrl // Same DID URL
+				);
+
+				const newVerificationMethods = [
+					...createDidVerificationMethod(
+						[VerificationMethods.Ed255192018],
+						[rotatedVerificationKeys1WithSameId]
+					), // Rotated key-1
+					...createDidVerificationMethod(
+						[VerificationMethods.Ed255192018],
+						[replacementVerificationKeys3WithSameDid]
+					), // New key-3
+				];
+
+				const combinedDidPayload = {
+					...initialDidPayload,
+					verificationMethod: newVerificationMethods,
+					// new authentication and assertionMethod: key-1 (rotated) + key-3 (new)
+					// must update assertionMethod as well otherwise it will fail validation
+					authentication: [
+						rotatedVerificationKeys1WithSameId.keyId,
+						replacementVerificationKeys3WithSameDid.keyId,
+					],
+					assertionMethod: [
+						rotatedVerificationKeys1WithSameId.keyId,
+						replacementVerificationKeys3WithSameDid.keyId,
+					],
+				};
+
+				// Need signatures from existing keys that can authorize the changes:
+				// - Old key-1 (for rotation authorization)
+				// - New key-1 (for rotation proof of possession) - same ID as old key-1
+				// Note: key-2 signature not needed since it doesn't exist in new DIDDoc
+				const combinedSignInputs: ISignInputs[] = [
+					// Old key-1 (authorization for rotation)
+					{
+						verificationMethodId: verificationKeys1.keyId,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+					// New key-1 material (proof of possession) - same ID, different material
+					{
+						verificationMethodId: rotatedVerificationKeys1WithSameId.keyId, // Same ID as old key-1
+						privateKeyHex: toString(fromString(keyPair1New.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+				const updateTx = await didModule.updateDidDocTx(
+					combinedSignInputs,
+					combinedDidPayload,
+					feePayer,
+					feeUpdate
+				);
+
+				expect(updateTx.code).toBe(0);
+
+				// Verify the complex operation worked
+				const queryResult = await didModule.queryDidDoc(initialDidPayload.id);
+				expect(queryResult.didDocument).toBeDefined();
+				expect(queryResult.didDocument?.verificationMethod).toHaveLength(2);
+
+				// Check that key-1 was rotated (same ID, different material)
+				const rotatedKey = queryResult.didDocument?.verificationMethod!.find(
+					(vm) => vm.id === verificationKeys1.keyId
+				);
+				expect(rotatedKey).toBeDefined();
+				expect(rotatedKey!.publicKeyBase58).not.toBe(initialDidPayload.verificationMethod![0].publicKeyBase58);
+
+				// Check that key-2 was replaced with key-3
+				const replacedKey = queryResult.didDocument?.verificationMethod!.find(
+					(vm) => vm.id === replacementVerificationKeys3WithSameDid.keyId
+				);
+				expect(replacedKey).toBeDefined();
+				expect(
+					queryResult.didDocument?.verificationMethod!.find(
+						(vm) => vm.id === verificationKeys2WithSameDid.keyId
+					)
+				).toBeUndefined();
+
+				// Check authentication was updated correctly
+				expect(queryResult.didDocument?.authentication).toEqual([
+					rotatedVerificationKeys1WithSameId.keyId,
+					replacementVerificationKeys3WithSameDid.keyId,
+				]);
+			},
+			defaultAsyncTxTimeout
+		);
+	});
+
+	describe('Edge Cases and Error Scenarios', () => {
+		it(
+			'should fail when attempting key rotation with external controllers',
+			async () => {
+				// Test that key rotation fails when DID has external controllers
+				// The blockchain doesn't support simultaneous key changes and controller authorization
+
+				// Create controller DID first
+				const controllerKeyPair = createKeyPairBase64();
+				const controllerVerificationKeys = createVerificationKeys(
+					controllerKeyPair.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1' // Use standard key fragment format
+				);
+				const controllerVerificationMethods = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[controllerVerificationKeys]
+				);
+				const controllerDidPayload = createDidPayload(controllerVerificationMethods, [
+					controllerVerificationKeys,
+				]);
+
+				const controllerSignInputs: ISignInputs[] = [
+					{
+						verificationMethodId: controllerDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(controllerKeyPair.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create controller DID
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				await didModule.createDidDocTx(controllerSignInputs, controllerDidPayload, feePayer, feeCreate);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Create target DID with external controller
+				const targetKeyPair = createKeyPairBase64();
+				const targetVerificationKeys = createVerificationKeys(
+					targetKeyPair.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1' // Use standard key fragment format
+				);
+				const targetVerificationMethods = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[targetVerificationKeys]
+				);
+				const targetDidPayload = {
+					...createDidPayload(targetVerificationMethods, [targetVerificationKeys]),
+					controller: [controllerDidPayload.id], // External controller
+					verificationMethod: [...targetVerificationMethods, ...controllerVerificationMethods], // Include verification methods
+				};
+
+				const targetSignInputs: ISignInputs[] = [
+					{
+						verificationMethodId: targetDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(targetKeyPair.privateKey, 'base64'), 'hex'),
+					},
+					{
+						verificationMethodId: controllerVerificationKeys.keyId, // Controller must also sign
+						privateKeyHex: toString(fromString(controllerKeyPair.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				// Create target DID with external controller
+				const createSignInputs = [...targetSignInputs];
+				try {
+					const didTx: DeliverTxResponse = await didModule.createDidDocTx(
+						createSignInputs,
+						targetDidPayload,
+						feePayer,
+						feeCreate
+					);
+				} catch (error: Error | any) {
+					// Expect failure due to external controller presence
+					expect(error.code).toBe(1205); // cheqd error code
+					expect(error.codespace).toBe('cheqd');
+					expect(error.log).toContain('payload: (verification_method: (1: (id: must have prefix:');
+				}
+			},
+			defaultAsyncTxTimeout
+		);
+		it(
+			'should fail when trying to rotate non-existent key',
+			async () => {
+				const keyPair1 = createKeyPairBase64();
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationMethods1 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys1]
+				);
+				const initialDidPayload = createDidPayload(verificationMethods1, [verificationKeys1]);
+
+				const signInputs1: ISignInputs[] = [
+					{
+						verificationMethodId: initialDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				await didModule.createDidDocTx(signInputs1, initialDidPayload, feePayer, feeCreate);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Try to rotate a key ID that doesn't exist
+				const keyPair2 = createKeyPairBase64();
+				const verificationKeys2 = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-2' // Different key fragment - simulates non-existent key
+				);
+				const verificationKeys2WithSameDid = {
+					...verificationKeys2,
+					didUrl: verificationKeys1.didUrl,
+				};
+
+				const verificationMethods2 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys2WithSameDid]
+				);
+				const invalidDidPayload = {
+					...initialDidPayload,
+					verificationMethod: verificationMethods2, // Non-existent key ID
+				};
+
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+
+				await expect(
+					didModule.updateDidDocTx(signInputs1, invalidDidPayload, feePayer, feeUpdate)
+				).rejects.toThrow();
+			},
+			defaultAsyncTxTimeout
+		);
+
+		it(
+			'should fail key operations with insufficient signatures',
+			async () => {
+				const keyPair1 = createKeyPairBase64();
+				const verificationKeys1 = createVerificationKeys(
+					keyPair1.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationMethods1 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys1]
+				);
+				const initialDidPayload = createDidPayload(verificationMethods1, [verificationKeys1]);
+
+				const signInputs1: ISignInputs[] = [
+					{
+						verificationMethodId: initialDidPayload.verificationMethod![0].id,
+						privateKeyHex: toString(fromString(keyPair1.privateKey, 'base64'), 'hex'),
+					},
+				];
+
+				const feeCreate = await DIDModule.generateCreateDidDocFees(feePayer);
+				await didModule.createDidDocTx(signInputs1, initialDidPayload, feePayer, feeCreate);
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Try rotation with missing new key signature
+				const keyPair2 = createKeyPairBase64();
+				const verificationKeys2 = createVerificationKeys(
+					keyPair2.publicKey,
+					MethodSpecificIdAlgo.Uuid,
+					'key-1'
+				);
+				const verificationKeys2WithSameId = {
+					...verificationKeys2,
+					didUrl: verificationKeys1.didUrl,
+					keyId: verificationKeys1.keyId,
+				};
+
+				const verificationMethods2 = createDidVerificationMethod(
+					[VerificationMethods.Ed255192018],
+					[verificationKeys2WithSameId]
+				);
+				const rotatedDidPayload = {
+					...initialDidPayload,
+					verificationMethod: verificationMethods2,
+				};
+
+				// Only provide old key signature (missing new key)
+				const feeUpdate = await DIDModule.generateUpdateDidDocFees(feePayer);
+
+				await expect(
+					didModule.updateDidDocTx(signInputs1, rotatedDidPayload, feePayer, feeUpdate)
+				).rejects.toThrow(/authentication does not match signatures.*is missing/);
+			},
+			defaultAsyncTxTimeout
+		);
+	});
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cheqd/sdk",
-	"version": "5.3.3",
+	"version": "5.3.3-develop.1",
 	"description": "A TypeScript SDK built with CosmJS to interact with the cheqd network ledger",
 	"license": "Apache-2.0",
 	"author": "Cheqd Foundation Limited (https://github.com/cheqd)",


### PR DESCRIPTION
This fixes the bug where the uniqueRequiredSignatures had authentication for the existing didDoc.
**The Problem:**
  When updating a DID document with controller rotation (removing the DID itself as a controller),
  the authentication validation was incorrectly requiring signatures from the rotated-out DID's keys,
  causing validation failures with the error "authentication does not match signatures: signature from key
  is missing".

 **Root Cause:** The controller rotation logic was incorrectly including the current DID itself in the list of
  external controllers when it was being removed from the controller list. This happened because
  rotatedControllers included the DID being rotated out, and the code was treating it as an external
  controller requiring additional authentication.

**Impact:** This fix allows proper controller rotation scenarios where a DID removes itself from its own
  controller list while maintaining external controllers, without requiring additional signatures from the DID's own
  keys that are being rotated out.