### PR TITLE
fix: use oracle fee pricing when module is available

### DIFF
--- a/cjs/src/index.ts
+++ b/cjs/src/index.ts
@@ -235,7 +235,7 @@ export class CheqdSDK {
 			this.options.modules.push(FeemarketModule as unknown as AbstractCheqdSDKModule);
 		}
 
-		// ensure oracle module is loaded, if not already, if testnet
+		// ensure oracle module is loaded, if not already, when available on the connected chain
 		if (
 			(await this.isOracleExtensionEnabled()) &&
 			!this.options.modules.find((module) => module instanceof OracleModule)

--- a/cjs/src/modules/did.ts
+++ b/cjs/src/modules/did.ts
@@ -359,6 +359,8 @@ export class DIDModule extends AbstractCheqdSDKModule {
 	/** Querier instance with DID extension capabilities */
 	querier: CheqdQuerier & DidExtension & OracleExtension;
 
+	private oracleFeesAvailability?: Promise<boolean>;
+
 	/**
 	 * Constructs a new DID module instance.
 	 *
@@ -744,21 +746,27 @@ export class DIDModule extends AbstractCheqdSDKModule {
 	}
 
 	private async shouldUseOracleFees(context?: IContext): Promise<boolean> {
-		if (!this.querier && context?.sdk?.querier) {
-			this.querier = context.sdk.querier;
+		if (!this.oracleFeesAvailability) {
+			this.oracleFeesAvailability = (async () => {
+				if (!this.querier && context?.sdk?.querier) {
+					this.querier = context.sdk.querier;
+				}
+
+				const oracle = (this.querier as Partial<OracleExtension> | undefined)?.[defaultOracleExtensionKey];
+				if (!oracle?.queryParams) {
+					return false;
+				}
+
+				try {
+					await oracle.queryParams();
+					return true;
+				} catch {
+					return false;
+				}
+			})();
 		}
 
-		const oracle = (this.querier as Partial<OracleExtension> | undefined)?.[defaultOracleExtensionKey];
-		if (!oracle?.queryParams) {
-			return false;
-		}
-
-		try {
-			await oracle.queryParams();
-			return true;
-		} catch {
-			return false;
-		}
+		return this.oracleFeesAvailability;
 	}
 
 	/**

--- a/cjs/src/modules/did.ts
+++ b/cjs/src/modules/did.ts
@@ -12,7 +12,6 @@ import {
 	DIDDocumentWithMetadata,
 	AuthenticationValidationResult,
 	DidFeeOptions,
-	CheqdNetwork,
 } from '../types';
 import {
 	MsgCreateDidDoc,
@@ -744,16 +743,22 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		};
 	}
 
-	private async resolveNetworkForFees(context?: IContext): Promise<CheqdNetwork> {
-		if (context?.sdk?.options?.rpcUrl) {
-			return await CheqdQuerier.detectNetwork(context.sdk.options.rpcUrl);
+	private async shouldUseOracleFees(context?: IContext): Promise<boolean> {
+		if (!this.querier && context?.sdk?.querier) {
+			this.querier = context.sdk.querier;
 		}
 
-		return context?.sdk?.options?.network ?? CheqdNetwork.Testnet;
-	}
+		const oracle = (this.querier as Partial<OracleExtension> | undefined)?.[defaultOracleExtensionKey];
+		if (!oracle?.queryParams) {
+			return false;
+		}
 
-	private async shouldUseOracleFees(context?: IContext): Promise<boolean> {
-		return (await this.resolveNetworkForFees(context)) === CheqdNetwork.Testnet;
+		try {
+			await oracle.queryParams();
+			return true;
+		} catch {
+			return false;
+		}
 	}
 
 	/**
@@ -893,27 +898,26 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		const operationFees = (() => {
 			switch (operation) {
 				case 'create':
-					return feeParams.params?.createDid.find(
-						(fee) => fee.denom === (feeOptions?.feeDenom ?? DIDModule.baseUsdDenom)
-					);
+					return feeParams.params?.createDid;
 				case 'update':
-					return feeParams.params?.updateDid.find(
-						(fee) => fee.denom === (feeOptions?.feeDenom ?? DIDModule.baseUsdDenom)
-					);
+					return feeParams.params?.updateDid;
 				case 'deactivate':
-					return feeParams.params?.deactivateDid.find(
-						(fee) => fee.denom === (feeOptions?.feeDenom ?? DIDModule.baseUsdDenom)
-					);
+					return feeParams.params?.deactivateDid;
 				default:
 					throw new Error('Unsupported operation for fee retrieval');
 			}
 		})();
 
-		if (!operationFees) {
+		const operationFee = feeOptions?.feeDenom
+			? operationFees?.find((fee) => fee.denom === feeOptions.feeDenom)
+			: (operationFees?.find((fee) => fee.denom === DIDModule.baseUsdDenom) ??
+				operationFees?.find((fee) => fee.denom === DIDModule.baseMinimalDenom));
+
+		if (!operationFee) {
 			throw new Error(`Fee parameters not found for operation: ${operation}`);
 		}
 
-		return operationFees;
+		return operationFee;
 	}
 
 	/**

--- a/cjs/src/modules/resource.ts
+++ b/cjs/src/modules/resource.ts
@@ -1,7 +1,7 @@
 import { AbstractCheqdSDKModule, MinimalImportableCheqdSDKModule } from './_';
 import { CheqdSigningStargateClient } from '../signer';
 import { EncodeObject, GeneratedType, parseCoins } from '@cosmjs/proto-signing-cjs';
-import { CheqdNetwork, DidFeeOptions, DidStdFee, IContext, ISignInputs, QueryExtensionSetup } from '../types';
+import { DidFeeOptions, DidStdFee, IContext, ISignInputs, QueryExtensionSetup } from '../types';
 import {
 	Metadata,
 	MsgCreateResource,
@@ -438,16 +438,22 @@ export class ResourceModule extends AbstractCheqdSDKModule {
 		return await this.querier[defaultResourceExtensionKey].latestResourceVersionMetadata(collectionId, name, type);
 	}
 
-	private async resolveNetworkForFees(context?: IContext): Promise<CheqdNetwork> {
-		if (context?.sdk?.options?.rpcUrl) {
-			return await CheqdQuerier.detectNetwork(context.sdk.options.rpcUrl);
+	private async shouldUseOracleFees(context?: IContext): Promise<boolean> {
+		if (!this.querier && context?.sdk?.querier) {
+			this.querier = context.sdk.querier;
 		}
 
-		return context?.sdk?.options?.network ?? CheqdNetwork.Testnet;
-	}
+		const oracle = (this.querier as Partial<OracleExtension> | undefined)?.[defaultOracleExtensionKey];
+		if (!oracle?.queryParams) {
+			return false;
+		}
 
-	private async shouldUseOracleFees(context?: IContext): Promise<boolean> {
-		return (await this.resolveNetworkForFees(context)) === CheqdNetwork.Testnet;
+		try {
+			await oracle.queryParams();
+			return true;
+		} catch {
+			return false;
+		}
 	}
 
 	/**
@@ -588,27 +594,26 @@ export class ResourceModule extends AbstractCheqdSDKModule {
 		const operationFees = (() => {
 			switch (operation) {
 				case 'image':
-					return feeParams.params?.image.find(
-						(fee) => fee.denom === (feeOptions?.feeDenom ?? ResourceModule.baseUsdDenom)
-					);
+					return feeParams.params?.image;
 				case 'json':
-					return feeParams.params?.json.find(
-						(fee) => fee.denom === (feeOptions?.feeDenom ?? ResourceModule.baseUsdDenom)
-					);
+					return feeParams.params?.json;
 				case 'default':
-					return feeParams.params?.default.find(
-						(fee) => fee.denom === (feeOptions?.feeDenom ?? ResourceModule.baseUsdDenom)
-					);
+					return feeParams.params?.default;
 				default:
 					throw new Error('Unsupported operation for fee retrieval');
 			}
 		})();
 
-		if (!operationFees) {
+		const operationFee = feeOptions?.feeDenom
+			? operationFees?.find((fee) => fee.denom === feeOptions.feeDenom)
+			: (operationFees?.find((fee) => fee.denom === ResourceModule.baseUsdDenom) ??
+				operationFees?.find((fee) => fee.denom === ResourceModule.baseMinimalDenom));
+
+		if (!operationFee) {
 			throw new Error(`Fee parameters not found for operation: ${operation}`);
 		}
 
-		return operationFees;
+		return operationFee;
 	}
 
 	/**

--- a/cjs/src/modules/resource.ts
+++ b/cjs/src/modules/resource.ts
@@ -212,6 +212,8 @@ export class ResourceModule extends AbstractCheqdSDKModule {
 	/** Querier instance with resource extension capabilities */
 	querier: CheqdQuerier & ResourceExtension & OracleExtension;
 
+	private oracleFeesAvailability?: Promise<boolean>;
+
 	/**
 	 * Constructs a new resource module instance.
 	 *
@@ -439,21 +441,27 @@ export class ResourceModule extends AbstractCheqdSDKModule {
 	}
 
 	private async shouldUseOracleFees(context?: IContext): Promise<boolean> {
-		if (!this.querier && context?.sdk?.querier) {
-			this.querier = context.sdk.querier;
+		if (!this.oracleFeesAvailability) {
+			this.oracleFeesAvailability = (async () => {
+				if (!this.querier && context?.sdk?.querier) {
+					this.querier = context.sdk.querier;
+				}
+
+				const oracle = (this.querier as Partial<OracleExtension> | undefined)?.[defaultOracleExtensionKey];
+				if (!oracle?.queryParams) {
+					return false;
+				}
+
+				try {
+					await oracle.queryParams();
+					return true;
+				} catch {
+					return false;
+				}
+			})();
 		}
 
-		const oracle = (this.querier as Partial<OracleExtension> | undefined)?.[defaultOracleExtensionKey];
-		if (!oracle?.queryParams) {
-			return false;
-		}
-
-		try {
-			await oracle.queryParams();
-			return true;
-		} catch {
-			return false;
-		}
+		return this.oracleFeesAvailability;
 	}
 
 	/**

--- a/cjs/tests/modules/did.test.ts
+++ b/cjs/tests/modules/did.test.ts
@@ -670,6 +670,62 @@ describe('DIDModule', () => {
 				DIDModule.gasLimits.DeactivateDidDocGasLimit,
 			]);
 		});
+
+		it('should memoize Oracle availability per DID module instance', async () => {
+			const feeRanges = {
+				create: {
+					denom: DIDModule.baseUsdDenom,
+					minAmount: '2000000000000000000',
+					maxAmount: '2000000000000000000',
+				},
+				update: {
+					denom: DIDModule.baseUsdDenom,
+					minAmount: '1000000000000000000',
+					maxAmount: '1000000000000000000',
+				},
+				deactivate: {
+					denom: DIDModule.baseUsdDenom,
+					minAmount: '500000000000000000',
+					maxAmount: '500000000000000000',
+				},
+			};
+			let oracleParamsCallCount = 0;
+			let didParamsCallCount = 0;
+			let convertCallCount = 0;
+			const mockQuerier = {
+				[defaultDidExtensionKey]: {
+					params: async () => {
+						didParamsCallCount += 1;
+						return {
+							params: {
+								createDid: [feeRanges.create],
+								updateDid: [feeRanges.update],
+								deactivateDid: [feeRanges.deactivate],
+							},
+						};
+					},
+				},
+				[defaultOracleExtensionKey]: {
+					queryParams: async () => {
+						oracleParamsCallCount += 1;
+						return { params: {} };
+					},
+					convertUSDtoCHEQ: async () => {
+						convertCallCount += 1;
+						return { amount: '50000000000ncheq' };
+					},
+				},
+			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
+			const didModule = new DIDModule({} as CheqdSigningStargateClient, mockQuerier);
+
+			await didModule.generateCreateDidDocFees(faucet.address);
+			await didModule.generateUpdateDidDocFees(faucet.address);
+			await didModule.generateDeactivateDidDocFees(faucet.address);
+
+			expect(oracleParamsCallCount).toBe(1);
+			expect(didParamsCallCount).toBe(3);
+			expect(convertCallCount).toBe(3);
+		});
 	});
 
 	describe('updateDidDocTx', () => {

--- a/cjs/tests/modules/did.test.ts
+++ b/cjs/tests/modules/did.test.ts
@@ -391,7 +391,7 @@ describe('DIDModule', () => {
 			defaultAsyncTxTimeout
 		);
 
-		it('should generate dynamic fees transacting on testnet - case: create', async () => {
+		it('should generate dynamic fees when Oracle module is available - case: create', async () => {
 			const feeRange = {
 				denom: DIDModule.baseUsdDenom,
 				minAmount: '2000000000000000000',
@@ -422,7 +422,7 @@ describe('DIDModule', () => {
 
 			const mockQuerier = {
 				[defaultDidExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
 
 			const didModule = new DIDModule({} as CheqdSigningStargateClient, mockQuerier);
@@ -436,22 +436,38 @@ describe('DIDModule', () => {
 			expect(fee.amount[0].amount).not.toBe(DIDModule.fees.DefaultCreateDidDocFee.amount);
 		});
 
-		it('should generate static fees transacting on mainnet - case: create', async () => {
+		it('should generate dynamic fees transacting on mainnet when Oracle module is available - case: create', async () => {
+			const feeRange = {
+				denom: DIDModule.baseUsdDenom,
+				minAmount: '2000000000000000000',
+				maxAmount: '2000000000000000000',
+			};
+			const paramsResponse = {
+				params: {
+					createDid: [feeRange],
+				},
+			};
+
 			let paramsCallCount = 0;
 			const params = async () => {
 				paramsCallCount += 1;
-				return { params: {} };
+				return paramsResponse;
 			};
 
-			let convertCallCount = 0;
-			const convertUSDtoCHEQ = async () => {
-				convertCallCount += 1;
-				return { amount: '0ncheq' };
+			let convertArgs;
+			const convertUSDtoCHEQ = async (
+				usdAmount: string,
+				movingAverage: MovingAverage,
+				wmaStrategy?: WMAStrategy,
+				weights?: bigint[]
+			) => {
+				convertArgs = [usdAmount, movingAverage, wmaStrategy, weights];
+				return { amount: '40000000000ncheq' };
 			};
 
 			const mockQuerier = {
 				[defaultDidExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
 
 			const context = {
@@ -466,11 +482,193 @@ describe('DIDModule', () => {
 				context
 			);
 
+			expect(paramsCallCount).toBe(1);
+			expect(convertArgs).toEqual([feeRange.minAmount, MovingAverages.WMA, WMAStrategies.BALANCED, undefined]);
+			expect(fee.amount).toEqual([{ amount: '40400000000', denom: DIDModule.baseMinimalDenom }]);
+			expect(fee.gas).toBe(DIDModule.gasLimits.CreateDidDocGasLimit);
+			expect(fee.payer).toBe(faucet.address);
+			expect(fee.amount[0].amount).not.toBe(DIDModule.fees.DefaultCreateDidDocFee.amount);
+		});
+
+		it('should generate static fees when Oracle module probing fails - case: create', async () => {
+			let paramsCallCount = 0;
+			const params = async () => {
+				paramsCallCount += 1;
+				return { params: {} };
+			};
+
+			let convertCallCount = 0;
+			const convertUSDtoCHEQ = async () => {
+				convertCallCount += 1;
+				return { amount: '0ncheq' };
+			};
+
+			const mockQuerier = {
+				[defaultDidExtensionKey]: { params },
+				[defaultOracleExtensionKey]: {
+					queryParams: async () => {
+						throw new Error('Oracle module unavailable');
+					},
+					convertUSDtoCHEQ,
+				},
+			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
+
+			const didModule = new DIDModule({} as CheqdSigningStargateClient, mockQuerier);
+			const fee = await didModule.generateCreateDidDocFees(faucet.address, undefined, { slippageBps: 100 });
+
 			expect(paramsCallCount).toBe(0);
 			expect(convertCallCount).toBe(0);
 			expect(fee.amount).toEqual([DIDModule.fees.DefaultCreateDidDocFee]);
 			expect(fee.gas).toBe(DIDModule.gasLimits.CreateDidDocGasLimit);
 			expect(fee.payer).toBe(faucet.address);
+		});
+
+		it('should auto-pick DID pricing params by denom when feeDenom is omitted', async () => {
+			const usdFeeRange = {
+				denom: DIDModule.baseUsdDenom,
+				minAmount: '2000000000000000000',
+				maxAmount: '2000000000000000000',
+			};
+			const ncheqFeeRange = {
+				denom: DIDModule.baseMinimalDenom,
+				minAmount: '12300000000',
+				maxAmount: '12300000000',
+			};
+
+			const generateFee = async (
+				createDid: { denom: string; minAmount: string; maxAmount: string }[],
+				feeDenom?: string
+			) => {
+				let convertCallCount = 0;
+				const mockQuerier = {
+					[defaultDidExtensionKey]: {
+						params: async () => ({ params: { createDid } }),
+					},
+					[defaultOracleExtensionKey]: {
+						queryParams: async () => ({ params: {} }),
+						convertUSDtoCHEQ: async () => {
+							convertCallCount += 1;
+							return { amount: '77700000000ncheq' };
+						},
+					},
+				} as unknown as CheqdQuerier & DidExtension & OracleExtension;
+				const didModule = new DIDModule({} as CheqdSigningStargateClient, mockQuerier);
+				const fee = await didModule.generateCreateDidDocFees(
+					faucet.address,
+					undefined,
+					feeDenom ? { feeDenom } : undefined
+				);
+				return { fee, convertCallCount };
+			};
+
+			const usdOnly = await generateFee([usdFeeRange]);
+			expect(usdOnly.convertCallCount).toBe(1);
+			expect(usdOnly.fee.amount).toEqual([{ amount: '77700000000', denom: DIDModule.baseMinimalDenom }]);
+
+			const ncheqOnly = await generateFee([ncheqFeeRange]);
+			expect(ncheqOnly.convertCallCount).toBe(0);
+			expect(ncheqOnly.fee.amount).toEqual([{ amount: ncheqFeeRange.minAmount, denom: ncheqFeeRange.denom }]);
+
+			const bothImplicit = await generateFee([ncheqFeeRange, usdFeeRange]);
+			expect(bothImplicit.convertCallCount).toBe(1);
+			expect(bothImplicit.fee.amount).toEqual([{ amount: '77700000000', denom: DIDModule.baseMinimalDenom }]);
+
+			const explicitNcheq = await generateFee([usdFeeRange, ncheqFeeRange], DIDModule.baseMinimalDenom);
+			expect(explicitNcheq.convertCallCount).toBe(0);
+			expect(explicitNcheq.fee.amount).toEqual([{ amount: ncheqFeeRange.minAmount, denom: ncheqFeeRange.denom }]);
+		});
+
+		it('should use Oracle fees when DID transactions are initiated without explicit fees', async () => {
+			const keyPair = createKeyPairBase64();
+			const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1');
+			const didPayload = createDidPayload(
+				createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys]),
+				[verificationKeys]
+			);
+			const signInputs = [
+				{
+					verificationMethodId: didPayload.verificationMethod![0].id,
+					signature: new Uint8Array([1]),
+				},
+			];
+			const feeRanges = {
+				create: {
+					denom: DIDModule.baseUsdDenom,
+					minAmount: '2000000000000000000',
+					maxAmount: '2000000000000000000',
+				},
+				update: {
+					denom: DIDModule.baseUsdDenom,
+					minAmount: '1000000000000000000',
+					maxAmount: '1000000000000000000',
+				},
+				deactivate: {
+					denom: DIDModule.baseUsdDenom,
+					minAmount: '500000000000000000',
+					maxAmount: '500000000000000000',
+				},
+			};
+			const convertedAmounts: Record<string, string> = {
+				[feeRanges.create.minAmount]: '40000000000ncheq',
+				[feeRanges.update.minAmount]: '20000000000ncheq',
+				[feeRanges.deactivate.minAmount]: '10000000000ncheq',
+			};
+			const broadcastFees: any[] = [];
+			const signer = {
+				signAndBroadcast: async (_address: string, _messages: unknown[], fee: unknown) => {
+					broadcastFees.push(fee);
+					return { code: 0 };
+				},
+			} as unknown as CheqdSigningStargateClient;
+			const mockQuerier = {
+				[defaultDidExtensionKey]: {
+					params: async () => ({
+						params: {
+							createDid: [feeRanges.create],
+							updateDid: [feeRanges.update],
+							deactivateDid: [feeRanges.deactivate],
+						},
+					}),
+				},
+				[defaultOracleExtensionKey]: {
+					queryParams: async () => ({ params: {} }),
+					convertUSDtoCHEQ: async (usdAmount: string) => ({ amount: convertedAmounts[usdAmount] }),
+				},
+			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
+			const didModule = new DIDModule(signer, mockQuerier);
+			const validateSpecCompliantPayload = DIDModule.validateSpecCompliantPayload;
+			const validateAuthenticationAgainstSignatures = DIDModule.validateAuthenticationAgainstSignatures;
+			const validateAuthenticationAgainstSignaturesKeyRotation =
+				DIDModule.validateAuthenticationAgainstSignaturesKeyRotation;
+			(DIDModule as any).validateSpecCompliantPayload = async () => ({
+				valid: true,
+				protobufVerificationMethod: [],
+				protobufService: [],
+			});
+			(DIDModule as any).validateAuthenticationAgainstSignatures = async () => ({ valid: true });
+			(DIDModule as any).validateAuthenticationAgainstSignaturesKeyRotation = async () => ({ valid: true });
+
+			try {
+				await didModule.createDidDocTx(signInputs as any, didPayload, faucet.address);
+				await didModule.updateDidDocTx(signInputs as any, didPayload, faucet.address);
+				await didModule.deactivateDidDocTx(signInputs as any, didPayload, faucet.address);
+			} finally {
+				(DIDModule as any).validateSpecCompliantPayload = validateSpecCompliantPayload;
+				(DIDModule as any).validateAuthenticationAgainstSignatures = validateAuthenticationAgainstSignatures;
+				(DIDModule as any).validateAuthenticationAgainstSignaturesKeyRotation =
+					validateAuthenticationAgainstSignaturesKeyRotation;
+			}
+
+			expect(broadcastFees.map((fee) => fee.amount)).toEqual([
+				[{ amount: '40000000000', denom: DIDModule.baseMinimalDenom }],
+				[{ amount: '20000000000', denom: DIDModule.baseMinimalDenom }],
+				[{ amount: '10000000000', denom: DIDModule.baseMinimalDenom }],
+			]);
+			expect(broadcastFees.map((fee) => fee.gas)).toEqual([
+				DIDModule.gasLimits.CreateDidDocGasLimit,
+				DIDModule.gasLimits.UpdateDidDocGasLimit,
+				DIDModule.gasLimits.DeactivateDidDocGasLimit,
+			]);
 		});
 	});
 
@@ -962,7 +1160,7 @@ describe('DIDModule', () => {
 			defaultAsyncTxTimeout
 		);
 
-		it('should generate dynamic fees transacting on testnet - case: update', async () => {
+		it('should generate dynamic fees when Oracle module is available - case: update', async () => {
 			const feeRange = {
 				denom: DIDModule.baseUsdDenom,
 				minAmount: '1000000000000000000',
@@ -993,7 +1191,7 @@ describe('DIDModule', () => {
 
 			const mockQuerier = {
 				[defaultDidExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
 
 			const didModule = new DIDModule({} as CheqdSigningStargateClient, mockQuerier);
@@ -1007,22 +1205,38 @@ describe('DIDModule', () => {
 			expect(fee.amount[0].amount).not.toBe(DIDModule.fees.DefaultUpdateDidDocFee.amount);
 		});
 
-		it('should generate static fees transacting on mainnet - case: update', async () => {
+		it('should generate dynamic fees transacting on mainnet when Oracle module is available - case: update', async () => {
+			const feeRange = {
+				denom: DIDModule.baseUsdDenom,
+				minAmount: '1000000000000000000',
+				maxAmount: '1000000000000000000',
+			};
+			const paramsResponse = {
+				params: {
+					updateDid: [feeRange],
+				},
+			};
+
 			let paramsCallCount = 0;
 			const params = async () => {
 				paramsCallCount += 1;
-				return { params: {} };
+				return paramsResponse;
 			};
 
-			let convertCallCount = 0;
-			const convertUSDtoCHEQ = async () => {
-				convertCallCount += 1;
-				return { amount: '0ncheq' };
+			let convertArgs: unknown[] | undefined;
+			const convertUSDtoCHEQ = async (
+				usdAmount: string,
+				movingAverage: MovingAverage,
+				wmaStrategy?: WMAStrategy,
+				weights?: bigint[]
+			) => {
+				convertArgs = [usdAmount, movingAverage, wmaStrategy, weights];
+				return { amount: '20000000000ncheq' };
 			};
 
 			const mockQuerier = {
 				[defaultDidExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
 
 			const context = {
@@ -1037,11 +1251,12 @@ describe('DIDModule', () => {
 				context
 			);
 
-			expect(paramsCallCount).toBe(0);
-			expect(convertCallCount).toBe(0);
-			expect(fee.amount).toEqual([DIDModule.fees.DefaultUpdateDidDocFee]);
+			expect(paramsCallCount).toBe(1);
+			expect(convertArgs).toEqual([feeRange.minAmount, MovingAverages.WMA, WMAStrategies.BALANCED, undefined]);
+			expect(fee.amount).toEqual([{ amount: '20200000000', denom: DIDModule.baseMinimalDenom }]);
 			expect(fee.gas).toBe(DIDModule.gasLimits.UpdateDidDocGasLimit);
 			expect(fee.payer).toBe(faucet.address);
+			expect(fee.amount[0].amount).not.toBe(DIDModule.fees.DefaultUpdateDidDocFee.amount);
 		});
 	});
 
@@ -1601,7 +1816,7 @@ describe('DIDModule', () => {
 			defaultAsyncTxTimeout
 		);
 
-		it('should generate dynamic fees transacting on testnet - case: deactivate', async () => {
+		it('should generate dynamic fees when Oracle module is available - case: deactivate', async () => {
 			const feeRange = {
 				denom: DIDModule.baseUsdDenom,
 				minAmount: '500000000000000000',
@@ -1632,7 +1847,7 @@ describe('DIDModule', () => {
 
 			const mockQuerier = {
 				[defaultDidExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
 
 			const didModule = new DIDModule({} as CheqdSigningStargateClient, mockQuerier);
@@ -1646,22 +1861,38 @@ describe('DIDModule', () => {
 			expect(fee.amount[0].amount).not.toBe(DIDModule.fees.DefaultDeactivateDidDocFee.amount);
 		});
 
-		it('should generate static fees transacting on mainnet - case: deactivate', async () => {
+		it('should generate dynamic fees transacting on mainnet when Oracle module is available - case: deactivate', async () => {
+			const feeRange = {
+				denom: DIDModule.baseUsdDenom,
+				minAmount: '500000000000000000',
+				maxAmount: '500000000000000000',
+			};
+			const paramsResponse = {
+				params: {
+					deactivateDid: [feeRange],
+				},
+			};
+
 			let paramsCallCount = 0;
 			const params = async () => {
 				paramsCallCount += 1;
-				return { params: {} };
+				return paramsResponse;
 			};
 
-			let convertCallCount = 0;
-			const convertUSDtoCHEQ = async () => {
-				convertCallCount += 1;
-				return { amount: '0ncheq' };
+			let convertArgs: unknown[] | undefined;
+			const convertUSDtoCHEQ = async (
+				usdAmount: string,
+				movingAverage: MovingAverage,
+				wmaStrategy?: WMAStrategy,
+				weights?: bigint[]
+			) => {
+				convertArgs = [usdAmount, movingAverage, wmaStrategy, weights];
+				return { amount: '10000000000ncheq' };
 			};
 
 			const mockQuerier = {
 				[defaultDidExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
 
 			const context = {
@@ -1676,11 +1907,12 @@ describe('DIDModule', () => {
 				context
 			);
 
-			expect(paramsCallCount).toBe(0);
-			expect(convertCallCount).toBe(0);
-			expect(fee.amount).toEqual([DIDModule.fees.DefaultDeactivateDidDocFee]);
+			expect(paramsCallCount).toBe(1);
+			expect(convertArgs).toEqual([feeRange.minAmount, MovingAverages.WMA, WMAStrategies.BALANCED, undefined]);
+			expect(fee.amount).toEqual([{ amount: '10100000000', denom: DIDModule.baseMinimalDenom }]);
 			expect(fee.gas).toBe(DIDModule.gasLimits.DeactivateDidDocGasLimit);
 			expect(fee.payer).toBe(faucet.address);
+			expect(fee.amount[0].amount).not.toBe(DIDModule.fees.DefaultDeactivateDidDocFee.amount);
 		});
 	});
 

--- a/cjs/tests/modules/resource.test.ts
+++ b/cjs/tests/modules/resource.test.ts
@@ -317,7 +317,7 @@ describe('ResourceModule', () => {
 			defaultAsyncTxTimeout
 		);
 
-		it('should generate dynamic fees transacting on testnet - case: json', async () => {
+		it('should generate dynamic fees when Oracle module is available - case: json', async () => {
 			const feeRange = {
 				denom: ResourceModule.baseUsdDenom,
 				minAmount: '400000000000000000',
@@ -348,7 +348,7 @@ describe('ResourceModule', () => {
 
 			const mockQuerier = {
 				[defaultResourceExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
 
 			const resourceModule = new ResourceModule({} as CheqdSigningStargateClient, mockQuerier);
@@ -365,7 +365,7 @@ describe('ResourceModule', () => {
 			expect(fee.amount[0].amount).not.toBe(ResourceModule.fees.DefaultCreateResourceJsonFee.amount);
 		});
 
-		it('should generate dynamic fees transacting on testnet - case: image', async () => {
+		it('should generate dynamic fees when Oracle module is available - case: image', async () => {
 			const feeRange = {
 				denom: ResourceModule.baseUsdDenom,
 				minAmount: '100000000000000000',
@@ -396,7 +396,7 @@ describe('ResourceModule', () => {
 
 			const mockQuerier = {
 				[defaultResourceExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
 
 			const resourceModule = new ResourceModule({} as CheqdSigningStargateClient, mockQuerier);
@@ -413,7 +413,7 @@ describe('ResourceModule', () => {
 			expect(fee.amount[0].amount).not.toBe(ResourceModule.fees.DefaultCreateResourceImageFee.amount);
 		});
 
-		it('should generate dynamic fees transacting on testnet - case: default', async () => {
+		it('should generate dynamic fees when Oracle module is available - case: default', async () => {
 			const feeRange = {
 				denom: ResourceModule.baseUsdDenom,
 				minAmount: '50000000000000000',
@@ -444,7 +444,7 @@ describe('ResourceModule', () => {
 
 			const mockQuerier = {
 				[defaultResourceExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
 
 			const resourceModule = new ResourceModule({} as CheqdSigningStargateClient, mockQuerier);
@@ -461,22 +461,38 @@ describe('ResourceModule', () => {
 			expect(fee.amount[0].amount).not.toBe(ResourceModule.fees.DefaultCreateResourceDefaultFee.amount);
 		});
 
-		it('should generate static fees transacting on mainnet - case: json', async () => {
+		it('should generate dynamic fees transacting on mainnet when Oracle module is available - case: json', async () => {
+			const feeRange = {
+				denom: ResourceModule.baseUsdDenom,
+				minAmount: '400000000000000000',
+				maxAmount: '400000000000000000',
+			};
+			const paramsResponse = {
+				params: {
+					json: [feeRange],
+				},
+			};
+
 			let paramsCallCount = 0;
 			const params = async () => {
 				paramsCallCount += 1;
-				return { params: {} };
+				return paramsResponse;
 			};
 
-			let convertCallCount = 0;
-			const convertUSDtoCHEQ = async () => {
-				convertCallCount += 1;
-				return { amount: '0ncheq' };
+			let convertArgs: unknown[] | undefined;
+			const convertUSDtoCHEQ = async (
+				usdAmount: string,
+				movingAverage: MovingAverage,
+				wmaStrategy?: WMAStrategy,
+				weights?: bigint[]
+			) => {
+				convertArgs = [usdAmount, movingAverage, wmaStrategy, weights];
+				return { amount: '50000000000ncheq' };
 			};
 
 			const mockQuerier = {
 				[defaultResourceExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
 
 			const context = {
@@ -491,29 +507,46 @@ describe('ResourceModule', () => {
 				context
 			);
 
-			expect(paramsCallCount).toBe(0);
-			expect(convertCallCount).toBe(0);
-			expect(fee.amount).toEqual([ResourceModule.fees.DefaultCreateResourceJsonFee]);
+			expect(paramsCallCount).toBe(1);
+			expect(convertArgs).toEqual([feeRange.minAmount, MovingAverages.WMA, WMAStrategies.BALANCED, undefined]);
+			expect(fee.amount).toEqual([{ amount: '50500000000', denom: ResourceModule.baseMinimalDenom }]);
 			expect(fee.gas).toBe(ResourceModule.gasLimits.CreateLinkedResourceJsonGasLimit);
 			expect(fee.payer).toBe(faucet.address);
+			expect(fee.amount[0].amount).not.toBe(ResourceModule.fees.DefaultCreateResourceJsonFee.amount);
 		});
 
-		it('should generate static fees transacting on mainnet - case: image', async () => {
+		it('should generate dynamic fees transacting on mainnet when Oracle module is available - case: image', async () => {
+			const feeRange = {
+				denom: ResourceModule.baseUsdDenom,
+				minAmount: '100000000000000000',
+				maxAmount: '100000000000000000',
+			};
+			const paramsResponse = {
+				params: {
+					image: [feeRange],
+				},
+			};
+
 			let paramsCallCount = 0;
 			const params = async () => {
 				paramsCallCount += 1;
-				return { params: {} };
+				return paramsResponse;
 			};
 
-			let convertCallCount = 0;
-			const convertUSDtoCHEQ = async () => {
-				convertCallCount += 1;
-				return { amount: '0ncheq' };
+			let convertArgs: unknown[] | undefined;
+			const convertUSDtoCHEQ = async (
+				usdAmount: string,
+				movingAverage: MovingAverage,
+				wmaStrategy?: WMAStrategy,
+				weights?: bigint[]
+			) => {
+				convertArgs = [usdAmount, movingAverage, wmaStrategy, weights];
+				return { amount: '20000000000ncheq' };
 			};
 
 			const mockQuerier = {
 				[defaultResourceExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
 
 			const context = {
@@ -528,29 +561,46 @@ describe('ResourceModule', () => {
 				context
 			);
 
-			expect(paramsCallCount).toBe(0);
-			expect(convertCallCount).toBe(0);
-			expect(fee.amount).toEqual([ResourceModule.fees.DefaultCreateResourceImageFee]);
+			expect(paramsCallCount).toBe(1);
+			expect(convertArgs).toEqual([feeRange.minAmount, MovingAverages.WMA, WMAStrategies.BALANCED, undefined]);
+			expect(fee.amount).toEqual([{ amount: '20200000000', denom: ResourceModule.baseMinimalDenom }]);
 			expect(fee.gas).toBe(ResourceModule.gasLimits.CreateLinkedResourceImageGasLimit);
 			expect(fee.payer).toBe(faucet.address);
+			expect(fee.amount[0].amount).not.toBe(ResourceModule.fees.DefaultCreateResourceImageFee.amount);
 		});
 
-		it('should generate static fees transacting on mainnet - case: default', async () => {
+		it('should generate dynamic fees transacting on mainnet when Oracle module is available - case: default', async () => {
+			const feeRange = {
+				denom: ResourceModule.baseUsdDenom,
+				minAmount: '50000000000000000',
+				maxAmount: '50000000000000000',
+			};
+			const paramsResponse = {
+				params: {
+					default: [feeRange],
+				},
+			};
+
 			let paramsCallCount = 0;
 			const params = async () => {
 				paramsCallCount += 1;
-				return { params: {} };
+				return paramsResponse;
 			};
 
-			let convertCallCount = 0;
-			const convertUSDtoCHEQ = async () => {
-				convertCallCount += 1;
-				return { amount: '0ncheq' };
+			let convertArgs: unknown[] | undefined;
+			const convertUSDtoCHEQ = async (
+				usdAmount: string,
+				movingAverage: MovingAverage,
+				wmaStrategy?: WMAStrategy,
+				weights?: bigint[]
+			) => {
+				convertArgs = [usdAmount, movingAverage, wmaStrategy, weights];
+				return { amount: '10000000000ncheq' };
 			};
 
 			const mockQuerier = {
 				[defaultResourceExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
 
 			const context = {
@@ -565,11 +615,137 @@ describe('ResourceModule', () => {
 				context
 			);
 
-			expect(paramsCallCount).toBe(0);
-			expect(convertCallCount).toBe(0);
-			expect(fee.amount).toEqual([ResourceModule.fees.DefaultCreateResourceDefaultFee]);
+			expect(paramsCallCount).toBe(1);
+			expect(convertArgs).toEqual([feeRange.minAmount, MovingAverages.WMA, WMAStrategies.BALANCED, undefined]);
+			expect(fee.amount).toEqual([{ amount: '10100000000', denom: ResourceModule.baseMinimalDenom }]);
 			expect(fee.gas).toBe(ResourceModule.gasLimits.CreateLinkedResourceDefaultGasLimit);
 			expect(fee.payer).toBe(faucet.address);
+			expect(fee.amount[0].amount).not.toBe(ResourceModule.fees.DefaultCreateResourceDefaultFee.amount);
+		});
+
+		it('should generate static fees when Oracle module is absent - case: json', async () => {
+			let paramsCallCount = 0;
+			const params = async () => {
+				paramsCallCount += 1;
+				return { params: {} };
+			};
+
+			const mockQuerier = {
+				[defaultResourceExtensionKey]: { params },
+			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
+
+			const resourceModule = new ResourceModule({} as CheqdSigningStargateClient, mockQuerier);
+			const fee = await resourceModule.generateCreateResourceJsonFees(faucet.address, undefined, {
+				slippageBps: 100,
+			});
+
+			expect(paramsCallCount).toBe(0);
+			expect(fee.amount).toEqual([ResourceModule.fees.DefaultCreateResourceJsonFee]);
+			expect(fee.gas).toBe(ResourceModule.gasLimits.CreateLinkedResourceJsonGasLimit);
+			expect(fee.payer).toBe(faucet.address);
+		});
+
+		it('should auto-pick Resource pricing params by denom when feeDenom is omitted', async () => {
+			const usdFeeRange = {
+				denom: ResourceModule.baseUsdDenom,
+				minAmount: '400000000000000000',
+				maxAmount: '400000000000000000',
+			};
+			const ncheqFeeRange = {
+				denom: ResourceModule.baseMinimalDenom,
+				minAmount: '32100000000',
+				maxAmount: '32100000000',
+			};
+
+			const generateFee = async (
+				json: { denom: string; minAmount: string; maxAmount: string }[],
+				feeDenom?: string
+			) => {
+				let convertCallCount = 0;
+				const mockQuerier = {
+					[defaultResourceExtensionKey]: {
+						params: async () => ({ params: { json } }),
+					},
+					[defaultOracleExtensionKey]: {
+						queryParams: async () => ({ params: {} }),
+						convertUSDtoCHEQ: async () => {
+							convertCallCount += 1;
+							return { amount: '88800000000ncheq' };
+						},
+					},
+				} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
+				const resourceModule = new ResourceModule({} as CheqdSigningStargateClient, mockQuerier);
+				const fee = await resourceModule.generateCreateResourceJsonFees(
+					faucet.address,
+					undefined,
+					feeDenom ? { feeDenom } : undefined
+				);
+				return { fee, convertCallCount };
+			};
+
+			const usdOnly = await generateFee([usdFeeRange]);
+			expect(usdOnly.convertCallCount).toBe(1);
+			expect(usdOnly.fee.amount).toEqual([{ amount: '88800000000', denom: ResourceModule.baseMinimalDenom }]);
+
+			const ncheqOnly = await generateFee([ncheqFeeRange]);
+			expect(ncheqOnly.convertCallCount).toBe(0);
+			expect(ncheqOnly.fee.amount).toEqual([{ amount: ncheqFeeRange.minAmount, denom: ncheqFeeRange.denom }]);
+
+			const bothImplicit = await generateFee([ncheqFeeRange, usdFeeRange]);
+			expect(bothImplicit.convertCallCount).toBe(1);
+			expect(bothImplicit.fee.amount).toEqual([
+				{ amount: '88800000000', denom: ResourceModule.baseMinimalDenom },
+			]);
+
+			const explicitNcheq = await generateFee([usdFeeRange, ncheqFeeRange], ResourceModule.baseMinimalDenom);
+			expect(explicitNcheq.convertCallCount).toBe(0);
+			expect(explicitNcheq.fee.amount).toEqual([{ amount: ncheqFeeRange.minAmount, denom: ncheqFeeRange.denom }]);
+		});
+
+		it('should use Oracle fees when Resource transactions are initiated without explicit fees', async () => {
+			const feeRange = {
+				denom: ResourceModule.baseUsdDenom,
+				minAmount: '400000000000000000',
+				maxAmount: '400000000000000000',
+			};
+			const broadcastFees: any[] = [];
+			const signer = {
+				signAndBroadcast: async (_address: string, _messages: unknown[], fee: unknown) => {
+					broadcastFees.push(fee);
+					return { code: 0 };
+				},
+			} as unknown as CheqdSigningStargateClient;
+			const mockQuerier = {
+				[defaultResourceExtensionKey]: {
+					params: async () => ({ params: { json: [feeRange] } }),
+				},
+				[defaultOracleExtensionKey]: {
+					queryParams: async () => ({ params: {} }),
+					convertUSDtoCHEQ: async () => ({ amount: '50000000000ncheq' }),
+				},
+			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
+			const resourceModule = new ResourceModule(signer, mockQuerier);
+			const resourcePayload: Partial<MsgCreateResourcePayload> = {
+				collectionId: v4(),
+				id: v4(),
+				name: 'Test Resource',
+				version: '1.0',
+				resourceType: 'test-resource-type',
+				data: fromString(json_content, 'utf-8'),
+			};
+			const signInputs = [
+				{
+					verificationMethodId: 'did:cheqd:testnet:test#key-1',
+					signature: new Uint8Array([1]),
+				},
+			];
+
+			await resourceModule.createLinkedResourceTx(signInputs as any, resourcePayload, faucet.address);
+
+			expect(broadcastFees.map((fee) => fee.amount)).toEqual([
+				[{ amount: '50000000000', denom: ResourceModule.baseMinimalDenom }],
+			]);
+			expect(broadcastFees[0].gas).toBe(ResourceModule.gasLimits.CreateLinkedResourceJsonGasLimit);
 		});
 	});
 

--- a/cjs/tests/modules/resource.test.ts
+++ b/cjs/tests/modules/resource.test.ts
@@ -747,6 +747,62 @@ describe('ResourceModule', () => {
 			]);
 			expect(broadcastFees[0].gas).toBe(ResourceModule.gasLimits.CreateLinkedResourceJsonGasLimit);
 		});
+
+		it('should memoize Oracle availability per Resource module instance', async () => {
+			const feeRanges = {
+				image: {
+					denom: ResourceModule.baseUsdDenom,
+					minAmount: '100000000000000000',
+					maxAmount: '100000000000000000',
+				},
+				json: {
+					denom: ResourceModule.baseUsdDenom,
+					minAmount: '400000000000000000',
+					maxAmount: '400000000000000000',
+				},
+				default: {
+					denom: ResourceModule.baseUsdDenom,
+					minAmount: '50000000000000000',
+					maxAmount: '50000000000000000',
+				},
+			};
+			let oracleParamsCallCount = 0;
+			let resourceParamsCallCount = 0;
+			let convertCallCount = 0;
+			const mockQuerier = {
+				[defaultResourceExtensionKey]: {
+					params: async () => {
+						resourceParamsCallCount += 1;
+						return {
+							params: {
+								image: [feeRanges.image],
+								json: [feeRanges.json],
+								default: [feeRanges.default],
+							},
+						};
+					},
+				},
+				[defaultOracleExtensionKey]: {
+					queryParams: async () => {
+						oracleParamsCallCount += 1;
+						return { params: {} };
+					},
+					convertUSDtoCHEQ: async () => {
+						convertCallCount += 1;
+						return { amount: '50000000000ncheq' };
+					},
+				},
+			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
+			const resourceModule = new ResourceModule({} as CheqdSigningStargateClient, mockQuerier);
+
+			await resourceModule.generateCreateResourceJsonFees(faucet.address);
+			await resourceModule.generateCreateResourceImageFees(faucet.address);
+			await resourceModule.generateCreateResourceDefaultFees(faucet.address);
+
+			expect(oracleParamsCallCount).toBe(1);
+			expect(resourceParamsCallCount).toBe(3);
+			expect(convertCallCount).toBe(3);
+		});
 	});
 
 	describe('queryLinkedResource', () => {

--- a/esm/src/index.ts
+++ b/esm/src/index.ts
@@ -238,7 +238,7 @@ export class CheqdSDK {
 			this.options.modules.push(FeemarketModule as unknown as AbstractCheqdSDKModule);
 		}
 
-		// ensure oracle module is loaded, if not already, if testnet
+		// ensure oracle module is loaded, if not already, when available on the connected chain
 		if (
 			(await this.isOracleExtensionEnabled()) &&
 			!this.options.modules.find((module) => module instanceof OracleModule)

--- a/esm/src/modules/did.ts
+++ b/esm/src/modules/did.ts
@@ -12,7 +12,6 @@ import {
 	DIDDocumentWithMetadata,
 	AuthenticationValidationResult,
 	DidFeeOptions,
-	CheqdNetwork,
 } from '../types.js';
 import {
 	MsgCreateDidDoc,
@@ -747,16 +746,22 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		};
 	}
 
-	private async resolveNetworkForFees(context?: IContext): Promise<CheqdNetwork> {
-		if (context?.sdk?.options?.rpcUrl) {
-			return await CheqdQuerier.detectNetwork(context.sdk.options.rpcUrl);
+	private async shouldUseOracleFees(context?: IContext): Promise<boolean> {
+		if (!this.querier && context?.sdk?.querier) {
+			this.querier = context.sdk.querier;
 		}
 
-		return context?.sdk?.options?.network ?? CheqdNetwork.Testnet;
-	}
+		const oracle = (this.querier as Partial<OracleExtension> | undefined)?.[defaultOracleExtensionKey];
+		if (!oracle?.queryParams) {
+			return false;
+		}
 
-	private async shouldUseOracleFees(context?: IContext): Promise<boolean> {
-		return (await this.resolveNetworkForFees(context)) === CheqdNetwork.Testnet;
+		try {
+			await oracle.queryParams();
+			return true;
+		} catch {
+			return false;
+		}
 	}
 
 	/**
@@ -896,27 +901,26 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		const operationFees = (() => {
 			switch (operation) {
 				case 'create':
-					return feeParams.params?.createDid.find(
-						(fee) => fee.denom === (feeOptions?.feeDenom ?? DIDModule.baseUsdDenom)
-					);
+					return feeParams.params?.createDid;
 				case 'update':
-					return feeParams.params?.updateDid.find(
-						(fee) => fee.denom === (feeOptions?.feeDenom ?? DIDModule.baseUsdDenom)
-					);
+					return feeParams.params?.updateDid;
 				case 'deactivate':
-					return feeParams.params?.deactivateDid.find(
-						(fee) => fee.denom === (feeOptions?.feeDenom ?? DIDModule.baseUsdDenom)
-					);
+					return feeParams.params?.deactivateDid;
 				default:
 					throw new Error('Unsupported operation for fee retrieval');
 			}
 		})();
 
-		if (!operationFees) {
+		const operationFee = feeOptions?.feeDenom
+			? operationFees?.find((fee) => fee.denom === feeOptions.feeDenom)
+			: (operationFees?.find((fee) => fee.denom === DIDModule.baseUsdDenom) ??
+				operationFees?.find((fee) => fee.denom === DIDModule.baseMinimalDenom));
+
+		if (!operationFee) {
 			throw new Error(`Fee parameters not found for operation: ${operation}`);
 		}
 
-		return operationFees;
+		return operationFee;
 	}
 
 	/**

--- a/esm/src/modules/did.ts
+++ b/esm/src/modules/did.ts
@@ -359,6 +359,8 @@ export class DIDModule extends AbstractCheqdSDKModule {
 	/** Querier instance with DID extension capabilities */
 	querier: CheqdQuerier & DidExtension & OracleExtension;
 
+	private oracleFeesAvailability?: Promise<boolean>;
+
 	/**
 	 * Constructs a new DID module instance.
 	 *
@@ -747,21 +749,27 @@ export class DIDModule extends AbstractCheqdSDKModule {
 	}
 
 	private async shouldUseOracleFees(context?: IContext): Promise<boolean> {
-		if (!this.querier && context?.sdk?.querier) {
-			this.querier = context.sdk.querier;
+		if (!this.oracleFeesAvailability) {
+			this.oracleFeesAvailability = (async () => {
+				if (!this.querier && context?.sdk?.querier) {
+					this.querier = context.sdk.querier;
+				}
+
+				const oracle = (this.querier as Partial<OracleExtension> | undefined)?.[defaultOracleExtensionKey];
+				if (!oracle?.queryParams) {
+					return false;
+				}
+
+				try {
+					await oracle.queryParams();
+					return true;
+				} catch {
+					return false;
+				}
+			})();
 		}
 
-		const oracle = (this.querier as Partial<OracleExtension> | undefined)?.[defaultOracleExtensionKey];
-		if (!oracle?.queryParams) {
-			return false;
-		}
-
-		try {
-			await oracle.queryParams();
-			return true;
-		} catch {
-			return false;
-		}
+		return this.oracleFeesAvailability;
 	}
 
 	/**

--- a/esm/src/modules/resource.ts
+++ b/esm/src/modules/resource.ts
@@ -1,7 +1,7 @@
 import { AbstractCheqdSDKModule, MinimalImportableCheqdSDKModule } from './_.js';
 import { CheqdSigningStargateClient } from '../signer.js';
 import { EncodeObject, GeneratedType, parseCoins } from '@cosmjs/proto-signing';
-import { CheqdNetwork, DidFeeOptions, DidStdFee, IContext, ISignInputs, QueryExtensionSetup } from '../types.js';
+import { DidFeeOptions, DidStdFee, IContext, ISignInputs, QueryExtensionSetup } from '../types.js';
 import {
 	Metadata,
 	MsgCreateResource,
@@ -438,16 +438,22 @@ export class ResourceModule extends AbstractCheqdSDKModule {
 		return await this.querier[defaultResourceExtensionKey].latestResourceVersionMetadata(collectionId, name, type);
 	}
 
-	private async resolveNetworkForFees(context?: IContext): Promise<CheqdNetwork> {
-		if (context?.sdk?.options?.rpcUrl) {
-			return await CheqdQuerier.detectNetwork(context.sdk.options.rpcUrl);
+	private async shouldUseOracleFees(context?: IContext): Promise<boolean> {
+		if (!this.querier && context?.sdk?.querier) {
+			this.querier = context.sdk.querier;
 		}
 
-		return context?.sdk?.options?.network ?? CheqdNetwork.Testnet;
-	}
+		const oracle = (this.querier as Partial<OracleExtension> | undefined)?.[defaultOracleExtensionKey];
+		if (!oracle?.queryParams) {
+			return false;
+		}
 
-	private async shouldUseOracleFees(context?: IContext): Promise<boolean> {
-		return (await this.resolveNetworkForFees(context)) === CheqdNetwork.Testnet;
+		try {
+			await oracle.queryParams();
+			return true;
+		} catch {
+			return false;
+		}
 	}
 
 	/**
@@ -588,27 +594,26 @@ export class ResourceModule extends AbstractCheqdSDKModule {
 		const operationFees = (() => {
 			switch (operation) {
 				case 'image':
-					return feeParams.params?.image.find(
-						(fee) => fee.denom === (feeOptions?.feeDenom ?? ResourceModule.baseUsdDenom)
-					);
+					return feeParams.params?.image;
 				case 'json':
-					return feeParams.params?.json.find(
-						(fee) => fee.denom === (feeOptions?.feeDenom ?? ResourceModule.baseUsdDenom)
-					);
+					return feeParams.params?.json;
 				case 'default':
-					return feeParams.params?.default.find(
-						(fee) => fee.denom === (feeOptions?.feeDenom ?? ResourceModule.baseUsdDenom)
-					);
+					return feeParams.params?.default;
 				default:
 					throw new Error('Unsupported operation for fee retrieval');
 			}
 		})();
 
-		if (!operationFees) {
+		const operationFee = feeOptions?.feeDenom
+			? operationFees?.find((fee) => fee.denom === feeOptions.feeDenom)
+			: (operationFees?.find((fee) => fee.denom === ResourceModule.baseUsdDenom) ??
+				operationFees?.find((fee) => fee.denom === ResourceModule.baseMinimalDenom));
+
+		if (!operationFee) {
 			throw new Error(`Fee parameters not found for operation: ${operation}`);
 		}
 
-		return operationFees;
+		return operationFee;
 	}
 
 	/**

--- a/esm/src/modules/resource.ts
+++ b/esm/src/modules/resource.ts
@@ -212,6 +212,8 @@ export class ResourceModule extends AbstractCheqdSDKModule {
 	/** Querier instance with resource extension capabilities */
 	querier: CheqdQuerier & ResourceExtension & OracleExtension;
 
+	private oracleFeesAvailability?: Promise<boolean>;
+
 	/**
 	 * Constructs a new resource module instance.
 	 *
@@ -439,21 +441,27 @@ export class ResourceModule extends AbstractCheqdSDKModule {
 	}
 
 	private async shouldUseOracleFees(context?: IContext): Promise<boolean> {
-		if (!this.querier && context?.sdk?.querier) {
-			this.querier = context.sdk.querier;
+		if (!this.oracleFeesAvailability) {
+			this.oracleFeesAvailability = (async () => {
+				if (!this.querier && context?.sdk?.querier) {
+					this.querier = context.sdk.querier;
+				}
+
+				const oracle = (this.querier as Partial<OracleExtension> | undefined)?.[defaultOracleExtensionKey];
+				if (!oracle?.queryParams) {
+					return false;
+				}
+
+				try {
+					await oracle.queryParams();
+					return true;
+				} catch {
+					return false;
+				}
+			})();
 		}
 
-		const oracle = (this.querier as Partial<OracleExtension> | undefined)?.[defaultOracleExtensionKey];
-		if (!oracle?.queryParams) {
-			return false;
-		}
-
-		try {
-			await oracle.queryParams();
-			return true;
-		} catch {
-			return false;
-		}
+		return this.oracleFeesAvailability;
 	}
 
 	/**

--- a/esm/tests/modules/did.test.ts
+++ b/esm/tests/modules/did.test.ts
@@ -670,6 +670,62 @@ describe('DIDModule', () => {
 				DIDModule.gasLimits.DeactivateDidDocGasLimit,
 			]);
 		});
+
+		it('should memoize Oracle availability per DID module instance', async () => {
+			const feeRanges = {
+				create: {
+					denom: DIDModule.baseUsdDenom,
+					minAmount: '2000000000000000000',
+					maxAmount: '2000000000000000000',
+				},
+				update: {
+					denom: DIDModule.baseUsdDenom,
+					minAmount: '1000000000000000000',
+					maxAmount: '1000000000000000000',
+				},
+				deactivate: {
+					denom: DIDModule.baseUsdDenom,
+					minAmount: '500000000000000000',
+					maxAmount: '500000000000000000',
+				},
+			};
+			let oracleParamsCallCount = 0;
+			let didParamsCallCount = 0;
+			let convertCallCount = 0;
+			const mockQuerier = {
+				[defaultDidExtensionKey]: {
+					params: async () => {
+						didParamsCallCount += 1;
+						return {
+							params: {
+								createDid: [feeRanges.create],
+								updateDid: [feeRanges.update],
+								deactivateDid: [feeRanges.deactivate],
+							},
+						};
+					},
+				},
+				[defaultOracleExtensionKey]: {
+					queryParams: async () => {
+						oracleParamsCallCount += 1;
+						return { params: {} };
+					},
+					convertUSDtoCHEQ: async () => {
+						convertCallCount += 1;
+						return { amount: '50000000000ncheq' };
+					},
+				},
+			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
+			const didModule = new DIDModule({} as CheqdSigningStargateClient, mockQuerier);
+
+			await didModule.generateCreateDidDocFees(faucet.address);
+			await didModule.generateUpdateDidDocFees(faucet.address);
+			await didModule.generateDeactivateDidDocFees(faucet.address);
+
+			expect(oracleParamsCallCount).toBe(1);
+			expect(didParamsCallCount).toBe(3);
+			expect(convertCallCount).toBe(3);
+		});
 	});
 
 	describe('updateDidDocTx', () => {

--- a/esm/tests/modules/did.test.ts
+++ b/esm/tests/modules/did.test.ts
@@ -391,7 +391,7 @@ describe('DIDModule', () => {
 			defaultAsyncTxTimeout
 		);
 
-		it('should generate dynamic fees transacting on testnet - case: create', async () => {
+		it('should generate dynamic fees when Oracle module is available - case: create', async () => {
 			const feeRange = {
 				denom: DIDModule.baseUsdDenom,
 				minAmount: '2000000000000000000',
@@ -422,7 +422,7 @@ describe('DIDModule', () => {
 
 			const mockQuerier = {
 				[defaultDidExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
 
 			const didModule = new DIDModule({} as CheqdSigningStargateClient, mockQuerier);
@@ -436,22 +436,38 @@ describe('DIDModule', () => {
 			expect(fee.amount[0].amount).not.toBe(DIDModule.fees.DefaultCreateDidDocFee.amount);
 		});
 
-		it('should generate static fees transacting on mainnet - case: create', async () => {
+		it('should generate dynamic fees transacting on mainnet when Oracle module is available - case: create', async () => {
+			const feeRange = {
+				denom: DIDModule.baseUsdDenom,
+				minAmount: '2000000000000000000',
+				maxAmount: '2000000000000000000',
+			};
+			const paramsResponse = {
+				params: {
+					createDid: [feeRange],
+				},
+			};
+
 			let paramsCallCount = 0;
 			const params = async () => {
 				paramsCallCount += 1;
-				return { params: {} };
+				return paramsResponse;
 			};
 
-			let convertCallCount = 0;
-			const convertUSDtoCHEQ = async () => {
-				convertCallCount += 1;
-				return { amount: '0ncheq' };
+			let convertArgs: unknown[] | undefined;
+			const convertUSDtoCHEQ = async (
+				usdAmount: string,
+				movingAverage: MovingAverage,
+				wmaStrategy?: WMAStrategy,
+				weights?: bigint[]
+			) => {
+				convertArgs = [usdAmount, movingAverage, wmaStrategy, weights];
+				return { amount: '40000000000ncheq' };
 			};
 
 			const mockQuerier = {
 				[defaultDidExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
 
 			const context = {
@@ -466,11 +482,193 @@ describe('DIDModule', () => {
 				context
 			);
 
+			expect(paramsCallCount).toBe(1);
+			expect(convertArgs).toEqual([feeRange.minAmount, MovingAverages.WMA, WMAStrategies.BALANCED, undefined]);
+			expect(fee.amount).toEqual([{ amount: '40400000000', denom: DIDModule.baseMinimalDenom }]);
+			expect(fee.gas).toBe(DIDModule.gasLimits.CreateDidDocGasLimit);
+			expect(fee.payer).toBe(faucet.address);
+			expect(fee.amount[0].amount).not.toBe(DIDModule.fees.DefaultCreateDidDocFee.amount);
+		});
+
+		it('should generate static fees when Oracle module probing fails - case: create', async () => {
+			let paramsCallCount = 0;
+			const params = async () => {
+				paramsCallCount += 1;
+				return { params: {} };
+			};
+
+			let convertCallCount = 0;
+			const convertUSDtoCHEQ = async () => {
+				convertCallCount += 1;
+				return { amount: '0ncheq' };
+			};
+
+			const mockQuerier = {
+				[defaultDidExtensionKey]: { params },
+				[defaultOracleExtensionKey]: {
+					queryParams: async () => {
+						throw new Error('Oracle module unavailable');
+					},
+					convertUSDtoCHEQ,
+				},
+			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
+
+			const didModule = new DIDModule({} as CheqdSigningStargateClient, mockQuerier);
+			const fee = await didModule.generateCreateDidDocFees(faucet.address, undefined, { slippageBps: 100 });
+
 			expect(paramsCallCount).toBe(0);
 			expect(convertCallCount).toBe(0);
 			expect(fee.amount).toEqual([DIDModule.fees.DefaultCreateDidDocFee]);
 			expect(fee.gas).toBe(DIDModule.gasLimits.CreateDidDocGasLimit);
 			expect(fee.payer).toBe(faucet.address);
+		});
+
+		it('should auto-pick DID pricing params by denom when feeDenom is omitted', async () => {
+			const usdFeeRange = {
+				denom: DIDModule.baseUsdDenom,
+				minAmount: '2000000000000000000',
+				maxAmount: '2000000000000000000',
+			};
+			const ncheqFeeRange = {
+				denom: DIDModule.baseMinimalDenom,
+				minAmount: '12300000000',
+				maxAmount: '12300000000',
+			};
+
+			const generateFee = async (
+				createDid: { denom: string; minAmount: string; maxAmount: string }[],
+				feeDenom?: string
+			) => {
+				let convertCallCount = 0;
+				const mockQuerier = {
+					[defaultDidExtensionKey]: {
+						params: async () => ({ params: { createDid } }),
+					},
+					[defaultOracleExtensionKey]: {
+						queryParams: async () => ({ params: {} }),
+						convertUSDtoCHEQ: async () => {
+							convertCallCount += 1;
+							return { amount: '77700000000ncheq' };
+						},
+					},
+				} as unknown as CheqdQuerier & DidExtension & OracleExtension;
+				const didModule = new DIDModule({} as CheqdSigningStargateClient, mockQuerier);
+				const fee = await didModule.generateCreateDidDocFees(
+					faucet.address,
+					undefined,
+					feeDenom ? { feeDenom } : undefined
+				);
+				return { fee, convertCallCount };
+			};
+
+			const usdOnly = await generateFee([usdFeeRange]);
+			expect(usdOnly.convertCallCount).toBe(1);
+			expect(usdOnly.fee.amount).toEqual([{ amount: '77700000000', denom: DIDModule.baseMinimalDenom }]);
+
+			const ncheqOnly = await generateFee([ncheqFeeRange]);
+			expect(ncheqOnly.convertCallCount).toBe(0);
+			expect(ncheqOnly.fee.amount).toEqual([{ amount: ncheqFeeRange.minAmount, denom: ncheqFeeRange.denom }]);
+
+			const bothImplicit = await generateFee([ncheqFeeRange, usdFeeRange]);
+			expect(bothImplicit.convertCallCount).toBe(1);
+			expect(bothImplicit.fee.amount).toEqual([{ amount: '77700000000', denom: DIDModule.baseMinimalDenom }]);
+
+			const explicitNcheq = await generateFee([usdFeeRange, ncheqFeeRange], DIDModule.baseMinimalDenom);
+			expect(explicitNcheq.convertCallCount).toBe(0);
+			expect(explicitNcheq.fee.amount).toEqual([{ amount: ncheqFeeRange.minAmount, denom: ncheqFeeRange.denom }]);
+		});
+
+		it('should use Oracle fees when DID transactions are initiated without explicit fees', async () => {
+			const keyPair = createKeyPairBase64();
+			const verificationKeys = createVerificationKeys(keyPair.publicKey, MethodSpecificIdAlgo.Base58, 'key-1');
+			const didPayload = createDidPayload(
+				createDidVerificationMethod([VerificationMethods.Ed255192020], [verificationKeys]),
+				[verificationKeys]
+			);
+			const signInputs = [
+				{
+					verificationMethodId: didPayload.verificationMethod![0].id,
+					signature: new Uint8Array([1]),
+				},
+			];
+			const feeRanges = {
+				create: {
+					denom: DIDModule.baseUsdDenom,
+					minAmount: '2000000000000000000',
+					maxAmount: '2000000000000000000',
+				},
+				update: {
+					denom: DIDModule.baseUsdDenom,
+					minAmount: '1000000000000000000',
+					maxAmount: '1000000000000000000',
+				},
+				deactivate: {
+					denom: DIDModule.baseUsdDenom,
+					minAmount: '500000000000000000',
+					maxAmount: '500000000000000000',
+				},
+			};
+			const convertedAmounts: Record<string, string> = {
+				[feeRanges.create.minAmount]: '40000000000ncheq',
+				[feeRanges.update.minAmount]: '20000000000ncheq',
+				[feeRanges.deactivate.minAmount]: '10000000000ncheq',
+			};
+			const broadcastFees: any[] = [];
+			const signer = {
+				signAndBroadcast: async (_address: string, _messages: unknown[], fee: unknown) => {
+					broadcastFees.push(fee);
+					return { code: 0 };
+				},
+			} as unknown as CheqdSigningStargateClient;
+			const mockQuerier = {
+				[defaultDidExtensionKey]: {
+					params: async () => ({
+						params: {
+							createDid: [feeRanges.create],
+							updateDid: [feeRanges.update],
+							deactivateDid: [feeRanges.deactivate],
+						},
+					}),
+				},
+				[defaultOracleExtensionKey]: {
+					queryParams: async () => ({ params: {} }),
+					convertUSDtoCHEQ: async (usdAmount: string) => ({ amount: convertedAmounts[usdAmount] }),
+				},
+			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
+			const didModule = new DIDModule(signer, mockQuerier);
+			const validateSpecCompliantPayload = DIDModule.validateSpecCompliantPayload;
+			const validateAuthenticationAgainstSignatures = DIDModule.validateAuthenticationAgainstSignatures;
+			const validateAuthenticationAgainstSignaturesKeyRotation =
+				DIDModule.validateAuthenticationAgainstSignaturesKeyRotation;
+			(DIDModule as any).validateSpecCompliantPayload = async () => ({
+				valid: true,
+				protobufVerificationMethod: [],
+				protobufService: [],
+			});
+			(DIDModule as any).validateAuthenticationAgainstSignatures = async () => ({ valid: true });
+			(DIDModule as any).validateAuthenticationAgainstSignaturesKeyRotation = async () => ({ valid: true });
+
+			try {
+				await didModule.createDidDocTx(signInputs as any, didPayload, faucet.address);
+				await didModule.updateDidDocTx(signInputs as any, didPayload, faucet.address);
+				await didModule.deactivateDidDocTx(signInputs as any, didPayload, faucet.address);
+			} finally {
+				(DIDModule as any).validateSpecCompliantPayload = validateSpecCompliantPayload;
+				(DIDModule as any).validateAuthenticationAgainstSignatures = validateAuthenticationAgainstSignatures;
+				(DIDModule as any).validateAuthenticationAgainstSignaturesKeyRotation =
+					validateAuthenticationAgainstSignaturesKeyRotation;
+			}
+
+			expect(broadcastFees.map((fee) => fee.amount)).toEqual([
+				[{ amount: '40000000000', denom: DIDModule.baseMinimalDenom }],
+				[{ amount: '20000000000', denom: DIDModule.baseMinimalDenom }],
+				[{ amount: '10000000000', denom: DIDModule.baseMinimalDenom }],
+			]);
+			expect(broadcastFees.map((fee) => fee.gas)).toEqual([
+				DIDModule.gasLimits.CreateDidDocGasLimit,
+				DIDModule.gasLimits.UpdateDidDocGasLimit,
+				DIDModule.gasLimits.DeactivateDidDocGasLimit,
+			]);
 		});
 	});
 
@@ -960,7 +1158,7 @@ describe('DIDModule', () => {
 			defaultAsyncTxTimeout
 		);
 
-		it('should generate dynamic fees transacting on testnet - case: update', async () => {
+		it('should generate dynamic fees when Oracle module is available - case: update', async () => {
 			const feeRange = {
 				denom: DIDModule.baseUsdDenom,
 				minAmount: '1000000000000000000',
@@ -991,7 +1189,7 @@ describe('DIDModule', () => {
 
 			const mockQuerier = {
 				[defaultDidExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
 
 			const didModule = new DIDModule({} as CheqdSigningStargateClient, mockQuerier);
@@ -1005,22 +1203,38 @@ describe('DIDModule', () => {
 			expect(fee.amount[0].amount).not.toBe(DIDModule.fees.DefaultUpdateDidDocFee.amount);
 		});
 
-		it('should generate static fees transacting on mainnet - case: update', async () => {
+		it('should generate dynamic fees transacting on mainnet when Oracle module is available - case: update', async () => {
+			const feeRange = {
+				denom: DIDModule.baseUsdDenom,
+				minAmount: '1000000000000000000',
+				maxAmount: '1000000000000000000',
+			};
+			const paramsResponse = {
+				params: {
+					updateDid: [feeRange],
+				},
+			};
+
 			let paramsCallCount = 0;
 			const params = async () => {
 				paramsCallCount += 1;
-				return { params: {} };
+				return paramsResponse;
 			};
 
-			let convertCallCount = 0;
-			const convertUSDtoCHEQ = async () => {
-				convertCallCount += 1;
-				return { amount: '0ncheq' };
+			let convertArgs: unknown[] | undefined;
+			const convertUSDtoCHEQ = async (
+				usdAmount: string,
+				movingAverage: MovingAverage,
+				wmaStrategy?: WMAStrategy,
+				weights?: bigint[]
+			) => {
+				convertArgs = [usdAmount, movingAverage, wmaStrategy, weights];
+				return { amount: '20000000000ncheq' };
 			};
 
 			const mockQuerier = {
 				[defaultDidExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
 
 			const context = {
@@ -1035,11 +1249,12 @@ describe('DIDModule', () => {
 				context
 			);
 
-			expect(paramsCallCount).toBe(0);
-			expect(convertCallCount).toBe(0);
-			expect(fee.amount).toEqual([DIDModule.fees.DefaultUpdateDidDocFee]);
+			expect(paramsCallCount).toBe(1);
+			expect(convertArgs).toEqual([feeRange.minAmount, MovingAverages.WMA, WMAStrategies.BALANCED, undefined]);
+			expect(fee.amount).toEqual([{ amount: '20200000000', denom: DIDModule.baseMinimalDenom }]);
 			expect(fee.gas).toBe(DIDModule.gasLimits.UpdateDidDocGasLimit);
 			expect(fee.payer).toBe(faucet.address);
+			expect(fee.amount[0].amount).not.toBe(DIDModule.fees.DefaultUpdateDidDocFee.amount);
 		});
 	});
 
@@ -1599,7 +1814,7 @@ describe('DIDModule', () => {
 			defaultAsyncTxTimeout
 		);
 
-		it('should generate dynamic fees transacting on testnet - case: deactivate', async () => {
+		it('should generate dynamic fees when Oracle module is available - case: deactivate', async () => {
 			const feeRange = {
 				denom: DIDModule.baseUsdDenom,
 				minAmount: '500000000000000000',
@@ -1630,7 +1845,7 @@ describe('DIDModule', () => {
 
 			const mockQuerier = {
 				[defaultDidExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
 
 			const didModule = new DIDModule({} as CheqdSigningStargateClient, mockQuerier);
@@ -1644,22 +1859,38 @@ describe('DIDModule', () => {
 			expect(fee.amount[0].amount).not.toBe(DIDModule.fees.DefaultDeactivateDidDocFee.amount);
 		});
 
-		it('should generate static fees transacting on mainnet - case: deactivate', async () => {
+		it('should generate dynamic fees transacting on mainnet when Oracle module is available - case: deactivate', async () => {
+			const feeRange = {
+				denom: DIDModule.baseUsdDenom,
+				minAmount: '500000000000000000',
+				maxAmount: '500000000000000000',
+			};
+			const paramsResponse = {
+				params: {
+					deactivateDid: [feeRange],
+				},
+			};
+
 			let paramsCallCount = 0;
 			const params = async () => {
 				paramsCallCount += 1;
-				return { params: {} };
+				return paramsResponse;
 			};
 
-			let convertCallCount = 0;
-			const convertUSDtoCHEQ = async () => {
-				convertCallCount += 1;
-				return { amount: '0ncheq' };
+			let convertArgs: unknown[] | undefined;
+			const convertUSDtoCHEQ = async (
+				usdAmount: string,
+				movingAverage: MovingAverage,
+				wmaStrategy?: WMAStrategy,
+				weights?: bigint[]
+			) => {
+				convertArgs = [usdAmount, movingAverage, wmaStrategy, weights];
+				return { amount: '10000000000ncheq' };
 			};
 
 			const mockQuerier = {
 				[defaultDidExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & DidExtension & OracleExtension;
 
 			const context = {
@@ -1674,11 +1905,12 @@ describe('DIDModule', () => {
 				context
 			);
 
-			expect(paramsCallCount).toBe(0);
-			expect(convertCallCount).toBe(0);
-			expect(fee.amount).toEqual([DIDModule.fees.DefaultDeactivateDidDocFee]);
+			expect(paramsCallCount).toBe(1);
+			expect(convertArgs).toEqual([feeRange.minAmount, MovingAverages.WMA, WMAStrategies.BALANCED, undefined]);
+			expect(fee.amount).toEqual([{ amount: '10100000000', denom: DIDModule.baseMinimalDenom }]);
 			expect(fee.gas).toBe(DIDModule.gasLimits.DeactivateDidDocGasLimit);
 			expect(fee.payer).toBe(faucet.address);
+			expect(fee.amount[0].amount).not.toBe(DIDModule.fees.DefaultDeactivateDidDocFee.amount);
 		});
 	});
 

--- a/esm/tests/modules/resource.test.ts
+++ b/esm/tests/modules/resource.test.ts
@@ -765,6 +765,62 @@ describe('ResourceModule', () => {
 			]);
 			expect(broadcastFees[0].gas).toBe(ResourceModule.gasLimits.CreateLinkedResourceJsonGasLimit);
 		});
+
+		it('should memoize Oracle availability per Resource module instance', async () => {
+			const feeRanges = {
+				image: {
+					denom: ResourceModule.baseUsdDenom,
+					minAmount: '100000000000000000',
+					maxAmount: '100000000000000000',
+				},
+				json: {
+					denom: ResourceModule.baseUsdDenom,
+					minAmount: '400000000000000000',
+					maxAmount: '400000000000000000',
+				},
+				default: {
+					denom: ResourceModule.baseUsdDenom,
+					minAmount: '50000000000000000',
+					maxAmount: '50000000000000000',
+				},
+			};
+			let oracleParamsCallCount = 0;
+			let resourceParamsCallCount = 0;
+			let convertCallCount = 0;
+			const mockQuerier = {
+				[defaultResourceExtensionKey]: {
+					params: async () => {
+						resourceParamsCallCount += 1;
+						return {
+							params: {
+								image: [feeRanges.image],
+								json: [feeRanges.json],
+								default: [feeRanges.default],
+							},
+						};
+					},
+				},
+				[defaultOracleExtensionKey]: {
+					queryParams: async () => {
+						oracleParamsCallCount += 1;
+						return { params: {} };
+					},
+					convertUSDtoCHEQ: async () => {
+						convertCallCount += 1;
+						return { amount: '50000000000ncheq' };
+					},
+				},
+			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
+			const resourceModule = new ResourceModule({} as CheqdSigningStargateClient, mockQuerier);
+
+			await resourceModule.generateCreateResourceJsonFees(faucet.address);
+			await resourceModule.generateCreateResourceImageFees(faucet.address);
+			await resourceModule.generateCreateResourceDefaultFees(faucet.address);
+
+			expect(oracleParamsCallCount).toBe(1);
+			expect(resourceParamsCallCount).toBe(3);
+			expect(convertCallCount).toBe(3);
+		});
 	});
 
 	describe('queryLinkedResource', () => {

--- a/esm/tests/modules/resource.test.ts
+++ b/esm/tests/modules/resource.test.ts
@@ -335,7 +335,7 @@ describe('ResourceModule', () => {
 			defaultAsyncTxTimeout
 		);
 
-		it('should generate dynamic fees transacting on testnet - case: json', async () => {
+		it('should generate dynamic fees when Oracle module is available - case: json', async () => {
 			const feeRange = {
 				denom: ResourceModule.baseUsdDenom,
 				minAmount: '400000000000000000',
@@ -366,7 +366,7 @@ describe('ResourceModule', () => {
 
 			const mockQuerier = {
 				[defaultResourceExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
 
 			const resourceModule = new ResourceModule({} as CheqdSigningStargateClient, mockQuerier);
@@ -383,7 +383,7 @@ describe('ResourceModule', () => {
 			expect(fee.amount[0].amount).not.toBe(ResourceModule.fees.DefaultCreateResourceJsonFee.amount);
 		});
 
-		it('should generate dynamic fees transacting on testnet - case: image', async () => {
+		it('should generate dynamic fees when Oracle module is available - case: image', async () => {
 			const feeRange = {
 				denom: ResourceModule.baseUsdDenom,
 				minAmount: '100000000000000000',
@@ -414,7 +414,7 @@ describe('ResourceModule', () => {
 
 			const mockQuerier = {
 				[defaultResourceExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
 
 			const resourceModule = new ResourceModule({} as CheqdSigningStargateClient, mockQuerier);
@@ -431,7 +431,7 @@ describe('ResourceModule', () => {
 			expect(fee.amount[0].amount).not.toBe(ResourceModule.fees.DefaultCreateResourceImageFee.amount);
 		});
 
-		it('should generate dynamic fees transacting on testnet - case: default', async () => {
+		it('should generate dynamic fees when Oracle module is available - case: default', async () => {
 			const feeRange = {
 				denom: ResourceModule.baseUsdDenom,
 				minAmount: '50000000000000000',
@@ -462,7 +462,7 @@ describe('ResourceModule', () => {
 
 			const mockQuerier = {
 				[defaultResourceExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
 
 			const resourceModule = new ResourceModule({} as CheqdSigningStargateClient, mockQuerier);
@@ -479,22 +479,38 @@ describe('ResourceModule', () => {
 			expect(fee.amount[0].amount).not.toBe(ResourceModule.fees.DefaultCreateResourceDefaultFee.amount);
 		});
 
-		it('should generate static fees transacting on mainnet - case: json', async () => {
+		it('should generate dynamic fees transacting on mainnet when Oracle module is available - case: json', async () => {
+			const feeRange = {
+				denom: ResourceModule.baseUsdDenom,
+				minAmount: '400000000000000000',
+				maxAmount: '400000000000000000',
+			};
+			const paramsResponse = {
+				params: {
+					json: [feeRange],
+				},
+			};
+
 			let paramsCallCount = 0;
 			const params = async () => {
 				paramsCallCount += 1;
-				return { params: {} };
+				return paramsResponse;
 			};
 
-			let convertCallCount = 0;
-			const convertUSDtoCHEQ = async () => {
-				convertCallCount += 1;
-				return { amount: '0ncheq' };
+			let convertArgs: unknown[] | undefined;
+			const convertUSDtoCHEQ = async (
+				usdAmount: string,
+				movingAverage: MovingAverage,
+				wmaStrategy?: WMAStrategy,
+				weights?: bigint[]
+			) => {
+				convertArgs = [usdAmount, movingAverage, wmaStrategy, weights];
+				return { amount: '50000000000ncheq' };
 			};
 
 			const mockQuerier = {
 				[defaultResourceExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
 
 			const context = {
@@ -509,29 +525,46 @@ describe('ResourceModule', () => {
 				context
 			);
 
-			expect(paramsCallCount).toBe(0);
-			expect(convertCallCount).toBe(0);
-			expect(fee.amount).toEqual([ResourceModule.fees.DefaultCreateResourceJsonFee]);
+			expect(paramsCallCount).toBe(1);
+			expect(convertArgs).toEqual([feeRange.minAmount, MovingAverages.WMA, WMAStrategies.BALANCED, undefined]);
+			expect(fee.amount).toEqual([{ amount: '50500000000', denom: ResourceModule.baseMinimalDenom }]);
 			expect(fee.gas).toBe(ResourceModule.gasLimits.CreateLinkedResourceJsonGasLimit);
 			expect(fee.payer).toBe(faucet.address);
+			expect(fee.amount[0].amount).not.toBe(ResourceModule.fees.DefaultCreateResourceJsonFee.amount);
 		});
 
-		it('should generate static fees transacting on mainnet - case: image', async () => {
+		it('should generate dynamic fees transacting on mainnet when Oracle module is available - case: image', async () => {
+			const feeRange = {
+				denom: ResourceModule.baseUsdDenom,
+				minAmount: '100000000000000000',
+				maxAmount: '100000000000000000',
+			};
+			const paramsResponse = {
+				params: {
+					image: [feeRange],
+				},
+			};
+
 			let paramsCallCount = 0;
 			const params = async () => {
 				paramsCallCount += 1;
-				return { params: {} };
+				return paramsResponse;
 			};
 
-			let convertCallCount = 0;
-			const convertUSDtoCHEQ = async () => {
-				convertCallCount += 1;
-				return { amount: '0ncheq' };
+			let convertArgs: unknown[] | undefined;
+			const convertUSDtoCHEQ = async (
+				usdAmount: string,
+				movingAverage: MovingAverage,
+				wmaStrategy?: WMAStrategy,
+				weights?: bigint[]
+			) => {
+				convertArgs = [usdAmount, movingAverage, wmaStrategy, weights];
+				return { amount: '20000000000ncheq' };
 			};
 
 			const mockQuerier = {
 				[defaultResourceExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
 
 			const context = {
@@ -546,29 +579,46 @@ describe('ResourceModule', () => {
 				context
 			);
 
-			expect(paramsCallCount).toBe(0);
-			expect(convertCallCount).toBe(0);
-			expect(fee.amount).toEqual([ResourceModule.fees.DefaultCreateResourceImageFee]);
+			expect(paramsCallCount).toBe(1);
+			expect(convertArgs).toEqual([feeRange.minAmount, MovingAverages.WMA, WMAStrategies.BALANCED, undefined]);
+			expect(fee.amount).toEqual([{ amount: '20200000000', denom: ResourceModule.baseMinimalDenom }]);
 			expect(fee.gas).toBe(ResourceModule.gasLimits.CreateLinkedResourceImageGasLimit);
 			expect(fee.payer).toBe(faucet.address);
+			expect(fee.amount[0].amount).not.toBe(ResourceModule.fees.DefaultCreateResourceImageFee.amount);
 		});
 
-		it('should generate static fees transacting on mainnet - case: default', async () => {
+		it('should generate dynamic fees transacting on mainnet when Oracle module is available - case: default', async () => {
+			const feeRange = {
+				denom: ResourceModule.baseUsdDenom,
+				minAmount: '50000000000000000',
+				maxAmount: '50000000000000000',
+			};
+			const paramsResponse = {
+				params: {
+					default: [feeRange],
+				},
+			};
+
 			let paramsCallCount = 0;
 			const params = async () => {
 				paramsCallCount += 1;
-				return { params: {} };
+				return paramsResponse;
 			};
 
-			let convertCallCount = 0;
-			const convertUSDtoCHEQ = async () => {
-				convertCallCount += 1;
-				return { amount: '0ncheq' };
+			let convertArgs: unknown[] | undefined;
+			const convertUSDtoCHEQ = async (
+				usdAmount: string,
+				movingAverage: MovingAverage,
+				wmaStrategy?: WMAStrategy,
+				weights?: bigint[]
+			) => {
+				convertArgs = [usdAmount, movingAverage, wmaStrategy, weights];
+				return { amount: '10000000000ncheq' };
 			};
 
 			const mockQuerier = {
 				[defaultResourceExtensionKey]: { params },
-				[defaultOracleExtensionKey]: { convertUSDtoCHEQ },
+				[defaultOracleExtensionKey]: { queryParams: async () => ({ params: {} }), convertUSDtoCHEQ },
 			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
 
 			const context = {
@@ -583,11 +633,137 @@ describe('ResourceModule', () => {
 				context
 			);
 
-			expect(paramsCallCount).toBe(0);
-			expect(convertCallCount).toBe(0);
-			expect(fee.amount).toEqual([ResourceModule.fees.DefaultCreateResourceDefaultFee]);
+			expect(paramsCallCount).toBe(1);
+			expect(convertArgs).toEqual([feeRange.minAmount, MovingAverages.WMA, WMAStrategies.BALANCED, undefined]);
+			expect(fee.amount).toEqual([{ amount: '10100000000', denom: ResourceModule.baseMinimalDenom }]);
 			expect(fee.gas).toBe(ResourceModule.gasLimits.CreateLinkedResourceDefaultGasLimit);
 			expect(fee.payer).toBe(faucet.address);
+			expect(fee.amount[0].amount).not.toBe(ResourceModule.fees.DefaultCreateResourceDefaultFee.amount);
+		});
+
+		it('should generate static fees when Oracle module is absent - case: json', async () => {
+			let paramsCallCount = 0;
+			const params = async () => {
+				paramsCallCount += 1;
+				return { params: {} };
+			};
+
+			const mockQuerier = {
+				[defaultResourceExtensionKey]: { params },
+			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
+
+			const resourceModule = new ResourceModule({} as CheqdSigningStargateClient, mockQuerier);
+			const fee = await resourceModule.generateCreateResourceJsonFees(faucet.address, undefined, {
+				slippageBps: 100,
+			});
+
+			expect(paramsCallCount).toBe(0);
+			expect(fee.amount).toEqual([ResourceModule.fees.DefaultCreateResourceJsonFee]);
+			expect(fee.gas).toBe(ResourceModule.gasLimits.CreateLinkedResourceJsonGasLimit);
+			expect(fee.payer).toBe(faucet.address);
+		});
+
+		it('should auto-pick Resource pricing params by denom when feeDenom is omitted', async () => {
+			const usdFeeRange = {
+				denom: ResourceModule.baseUsdDenom,
+				minAmount: '400000000000000000',
+				maxAmount: '400000000000000000',
+			};
+			const ncheqFeeRange = {
+				denom: ResourceModule.baseMinimalDenom,
+				minAmount: '32100000000',
+				maxAmount: '32100000000',
+			};
+
+			const generateFee = async (
+				json: { denom: string; minAmount: string; maxAmount: string }[],
+				feeDenom?: string
+			) => {
+				let convertCallCount = 0;
+				const mockQuerier = {
+					[defaultResourceExtensionKey]: {
+						params: async () => ({ params: { json } }),
+					},
+					[defaultOracleExtensionKey]: {
+						queryParams: async () => ({ params: {} }),
+						convertUSDtoCHEQ: async () => {
+							convertCallCount += 1;
+							return { amount: '88800000000ncheq' };
+						},
+					},
+				} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
+				const resourceModule = new ResourceModule({} as CheqdSigningStargateClient, mockQuerier);
+				const fee = await resourceModule.generateCreateResourceJsonFees(
+					faucet.address,
+					undefined,
+					feeDenom ? { feeDenom } : undefined
+				);
+				return { fee, convertCallCount };
+			};
+
+			const usdOnly = await generateFee([usdFeeRange]);
+			expect(usdOnly.convertCallCount).toBe(1);
+			expect(usdOnly.fee.amount).toEqual([{ amount: '88800000000', denom: ResourceModule.baseMinimalDenom }]);
+
+			const ncheqOnly = await generateFee([ncheqFeeRange]);
+			expect(ncheqOnly.convertCallCount).toBe(0);
+			expect(ncheqOnly.fee.amount).toEqual([{ amount: ncheqFeeRange.minAmount, denom: ncheqFeeRange.denom }]);
+
+			const bothImplicit = await generateFee([ncheqFeeRange, usdFeeRange]);
+			expect(bothImplicit.convertCallCount).toBe(1);
+			expect(bothImplicit.fee.amount).toEqual([
+				{ amount: '88800000000', denom: ResourceModule.baseMinimalDenom },
+			]);
+
+			const explicitNcheq = await generateFee([usdFeeRange, ncheqFeeRange], ResourceModule.baseMinimalDenom);
+			expect(explicitNcheq.convertCallCount).toBe(0);
+			expect(explicitNcheq.fee.amount).toEqual([{ amount: ncheqFeeRange.minAmount, denom: ncheqFeeRange.denom }]);
+		});
+
+		it('should use Oracle fees when Resource transactions are initiated without explicit fees', async () => {
+			const feeRange = {
+				denom: ResourceModule.baseUsdDenom,
+				minAmount: '400000000000000000',
+				maxAmount: '400000000000000000',
+			};
+			const broadcastFees: any[] = [];
+			const signer = {
+				signAndBroadcast: async (_address: string, _messages: unknown[], fee: unknown) => {
+					broadcastFees.push(fee);
+					return { code: 0 };
+				},
+			} as unknown as CheqdSigningStargateClient;
+			const mockQuerier = {
+				[defaultResourceExtensionKey]: {
+					params: async () => ({ params: { json: [feeRange] } }),
+				},
+				[defaultOracleExtensionKey]: {
+					queryParams: async () => ({ params: {} }),
+					convertUSDtoCHEQ: async () => ({ amount: '50000000000ncheq' }),
+				},
+			} as unknown as CheqdQuerier & ResourceExtension & OracleExtension;
+			const resourceModule = new ResourceModule(signer, mockQuerier);
+			const resourcePayload: Partial<MsgCreateResourcePayload> = {
+				collectionId: v4(),
+				id: v4(),
+				name: 'Test Resource',
+				version: '1.0',
+				resourceType: 'test-resource-type',
+				data: fromString(json_content, 'utf-8'),
+			};
+			const signInputs = [
+				{
+					verificationMethodId: 'did:cheqd:testnet:test#key-1',
+					signature: new Uint8Array([1]),
+				},
+			];
+
+			await resourceModule.createLinkedResourceTx(signInputs as any, resourcePayload, faucet.address);
+
+			expect(broadcastFees.map((fee) => fee.amount)).toEqual([
+				[{ amount: '50000000000', denom: ResourceModule.baseMinimalDenom }],
+			]);
+			expect(broadcastFees[0].gas).toBe(ResourceModule.gasLimits.CreateLinkedResourceJsonGasLimit);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Use Oracle module availability, not network name, to decide DID and DLR fee pricing.
- Auto-pick module pricing params when `feeDenom` is omitted, preferring `usd` and falling back to `ncheq`.
- Add mirrored ESM/CJS coverage for mainnet Oracle pricing, fallback static fees, denom selection, and automatic transaction fee generation.

## Root Cause
Mainnet fell back to static fees because `shouldUseOracleFees()` only allowed Oracle pricing on testnet.

## Validation
- `cd esm && npm test -- --runTestsByPath tests/modules/did.test.ts tests/modules/resource.test.ts --testNamePattern "Oracle module is available|mainnet when Oracle module is available|Oracle module probing fails|Oracle module is absent|auto-pick|transactions are initiated without explicit fees"`
- `cd cjs && npm test -- --runTestsByPath tests/modules/did.test.ts tests/modules/resource.test.ts --testNamePattern "Oracle module is available|mainnet when Oracle module is available|Oracle module probing fails|Oracle module is absent|auto-pick|transactions are initiated without explicit fees"`
- `cd esm && npm run build:esm`
- `cd cjs && npm run build:cjs`